### PR TITLE
Fix Signal Modulator requirement for Senior Staff wristband for all scenarios

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -2015,7 +2015,9 @@
         "region": "Greenhouse",
         "original_item": "ID Wristband - Senior Staff",
         "force_item": "ID Wristband - Senior Staff",
-        "condition": {},    
+        "condition": {
+            "items": ["Signal Modulator"]
+        },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -2131,7 +2131,9 @@
         "region": "Greenhouse",
         "original_item": "ID Wristband - Senior Staff",
         "force_item": "ID Wristband - Senior Staff",
-        "condition": {},    
+        "condition": {
+            "items": ["Signal Modulator"]
+        },     
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -2067,7 +2067,9 @@
         "region": "Greenhouse",
         "original_item": "ID Wristband - Senior Staff",
         "force_item": "ID Wristband - Senior Staff",
-        "condition": {},    
+        "condition": {
+            "items": ["Signal Modulator"]
+        },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -2096,7 +2096,9 @@
         "region": "Greenhouse",
         "original_item": "ID Wristband - Senior Staff",
         "force_item": "ID Wristband - Senior Staff",
-        "condition": {},    
+        "condition": {
+            "items": ["Signal Modulator"]
+        },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"


### PR DESCRIPTION
Update `ID Wristband - Senior Staff` to require `Signal Modulator` across all scenarios to fix logic for Universal Tracker users. 