### PR TITLE
Various fixes

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -285,7 +285,7 @@
     },
     {
         "name": "Downed Zombie 2F",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Handgun Ammo",
         "condition": {},    
         "item_object": "sm70_100",
@@ -294,7 +294,7 @@
     },
     {
         "name": "By Coffee Vending Machine",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Red Herb",
         "condition": {},    
         "item_object": "sm70_002",
@@ -339,7 +339,7 @@
     },
     {
         "name": "Couch",
-        "region": "West Hallway 2F",
+        "region": "STARS Office Hallway",
         "original_item": "Flame Rounds",
         "condition": {},    
         "item_object": "sm70_108",

--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -284,7 +284,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom"
     },
     {
-        "name": "Downed Zombie 2F",
+        "name": "Downed Zombie",
         "region": "West Hallway 2F",
         "original_item": "Handgun Ammo",
         "condition": {},    

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -43,7 +43,7 @@
     },
     {
         "from": "Reception - RPD",
-        "to": "West Hallway"
+        "to": "Southwest Hallway"
     },
     { 
         "from": "Operations Room 2",
@@ -53,7 +53,7 @@
         }
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Operations Room",
         "condition": {}
     },
@@ -98,6 +98,11 @@
     },
     { 
         "from": "West Hallway 1F",
+        "to": "West Hallway 2F",
+        "condition": {}
+    },
+    { 
+        "from": "West Hallway 2F",
         "to": "Shower Room",
         "condition": {
             "items": ["Valve Handle"]
@@ -105,11 +110,11 @@
     },
     { 
         "from": "Shower Room",
-        "to": "West Hallway 2F",
+        "to": "STARS Office Hallway",
         "condition": {}
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "STARS Office",
         "condition": {}
     },
@@ -121,14 +126,14 @@
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Linen Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
         "condition": {
             "items": ["Battery"]

--- a/residentevil2remake/data/claire/a/regions.json
+++ b/residentevil2remake/data/claire/a/regions.json
@@ -32,7 +32,7 @@
         "zone_id": 1
     },
     {
-        "name": "West Hallway",
+        "name": "Southwest Hallway",
         "zone_id": 1
     },
     {
@@ -93,6 +93,10 @@
     },
     {
         "name": "Shower Room",
+        "zone_id": 1
+    },
+    {
+        "name": "STARS Office Hallway",
         "zone_id": 1
     },
     {

--- a/residentevil2remake/data/claire/a/typewriters.json
+++ b/residentevil2remake/data/claire/a/typewriters.json
@@ -48,7 +48,7 @@
     { 
         "name": "Sewers - Office", 
         "location_id": 17, 
-        "map_id": 332, 
+        "map_id": 320, 
         "player_position": [1.46, -48.9, -46.91], 
         "item_object": "Typewriter01A_waterWater03_control"
     },

--- a/residentevil2remake/data/claire/a/typewriters.json
+++ b/residentevil2remake/data/claire/a/typewriters.json
@@ -37,6 +37,15 @@
     },
 
     { 
+        "name": "Orphanage - Directors Room", 
+        "location_id": 24, 
+        "map_id": 361, 
+        "player_position": [47.45, 0.95, -212.72], 
+        "item_object": "OrphanAsylum_sm41_000_Typewriter01A_control",
+        "line_break": true
+    },
+
+    { 
         "name": "Sewers - Office", 
         "location_id": 17, 
         "map_id": 332, 

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -357,7 +357,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom"
     },
     {
-        "name": "Downed Zombie 2F",
+        "name": "Downed Zombie",
         "region": "West Hallway 2F",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -358,7 +358,7 @@
     },
     {
         "name": "Downed Zombie 2F",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
         "item_object": "sm70_111",
@@ -367,7 +367,7 @@
     },
     {
         "name": "By Coffee Vending Machine",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Red Herb",
         "condition": {},    
         "item_object": "sm70_002",
@@ -412,7 +412,7 @@
     },
     {
         "name": "Couch",
-        "region": "West Hallway 2F",
+        "region": "STARS Office Hallway",
         "original_item": "Flame Rounds",
         "condition": {},    
         "item_object": "sm70_108",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1456,15 +1456,6 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/Magnum"
     },
     {
-        "name": "At Water Gate",
-        "region": "Upper Waterway",
-        "original_item": "Large-Caliber Handgun Ammo",
-        "condition": {},    
-        "item_object": "sm70_111",
-        "parent_object": "sm70_111",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
-    },
-    {
         "name": "In Front of Gate",
         "region": "Upper Waterway",
         "original_item": "High-Powered Rounds",
@@ -1716,6 +1707,15 @@
         "item_object": "sm73_429",
         "parent_object": "Key_Gesui_ura",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
+    },
+    {
+        "name": "At Water Gate",
+        "region": "Upper Waterway",
+        "original_item": "Large-Caliber Handgun Ammo",
+        "condition": {},    
+        "item_object": "sm70_111",
+        "parent_object": "sm70_111",
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
         "name": "Before Climb",

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -84,7 +84,7 @@
     },
     {
         "from": "Reception - RPD",
-        "to": "West Hallway"
+        "to": "Southwest Hallway"
     },
     { 
         "from": "Operations Room 2",
@@ -94,7 +94,7 @@
         }
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Operations Room",
         "condition": {}
     },
@@ -139,6 +139,11 @@
     },
     { 
         "from": "West Hallway 1F",
+        "to": "West Hallway 2F",
+        "condition": {}
+    },
+    { 
+        "from": "West Hallway 2F",
         "to": "Shower Room",
         "condition": {
             "items": ["Valve Handle"]
@@ -146,11 +151,11 @@
     },
     { 
         "from": "Shower Room",
-        "to": "West Hallway 2F",
+        "to": "STARS Office Hallway",
         "condition": {}
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "STARS Office",
         "condition": {}
     },
@@ -162,14 +167,14 @@
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Linen Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
         "condition": {
             "items": ["Battery"]

--- a/residentevil2remake/data/claire/b/regions.json
+++ b/residentevil2remake/data/claire/b/regions.json
@@ -68,7 +68,7 @@
         "zone_id": 1
     },
     {
-        "name": "West Hallway",
+        "name": "Southwest Hallway",
         "zone_id": 1
     },
     {
@@ -101,6 +101,10 @@
     },
     {
         "name": "Shower Room",
+        "zone_id": 1
+    },
+    {
+        "name": "STARS Office Hallway",
         "zone_id": 1
     },
     {

--- a/residentevil2remake/data/claire/b/typewriters.json
+++ b/residentevil2remake/data/claire/b/typewriters.json
@@ -48,7 +48,7 @@
     { 
         "name": "Sewers - Office", 
         "location_id": 17, 
-        "map_id": 332, 
+        "map_id": 320, 
         "player_position": [1.46, -48.9, -46.91], 
         "item_object": "Typewriter01A_waterWater03_control"
     },

--- a/residentevil2remake/data/claire/b/typewriters.json
+++ b/residentevil2remake/data/claire/b/typewriters.json
@@ -37,6 +37,15 @@
     },
 
     { 
+        "name": "Orphanage - Directors Room", 
+        "location_id": 24, 
+        "map_id": 361, 
+        "player_position": [47.45, 0.95, -212.72], 
+        "item_object": "OrphanAsylum_sm41_000_Typewriter01A_control",
+        "line_break": true
+    },
+
+    { 
         "name": "Sewers - Office", 
         "location_id": 17, 
         "map_id": 332, 

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -297,7 +297,7 @@
     },
     {
         "name": "Downed Zombie 2F",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Handgun Ammo",
         "condition": {},    
         "item_object": "sm70_100",
@@ -306,7 +306,7 @@
     },
     {
         "name": "By Coffee Vending Machine",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Red Herb",
         "condition": {},    
         "item_object": "sm70_002",
@@ -351,7 +351,7 @@
     },
     {
         "name": "Couch",
-        "region": "West Hallway 2F",
+        "region": "STARS Office Hallway",
         "original_item": "Shotgun Shells",
         "condition": {},    
         "item_object": "sm70_101",

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -296,7 +296,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom"
     },
     {
-        "name": "Downed Zombie 2F",
+        "name": "Downed Zombie",
         "region": "West Hallway 2F",
         "original_item": "Handgun Ammo",
         "condition": {},    

--- a/residentevil2remake/data/leon/a/region_connections.json
+++ b/residentevil2remake/data/leon/a/region_connections.json
@@ -43,17 +43,17 @@
     },
     {
         "from": "Reception - RPD",
-        "to": "West Hallway"
+        "to": "Southwest Hallway"
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Records Room",
         "condition": {
             "items": ["Club Key"]
         }
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Operations Room",
         "condition": {}
     },
@@ -98,6 +98,11 @@
     },
     { 
         "from": "West Hallway 1F",
+        "to": "West Hallway 2F",
+        "condition": {}
+    },
+    { 
+        "from": "West Hallway 2F",
         "to": "Shower Room",
         "condition": {
             "items": ["Valve Handle"]
@@ -105,11 +110,11 @@
     },
     { 
         "from": "Shower Room",
-        "to": "West Hallway 2F",
+        "to": "STARS Office Hallway",
         "condition": {}
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "STARS Office",
         "condition": {}
     },
@@ -121,14 +126,14 @@
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Linen Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
         "condition": {
             "items": ["Battery"]

--- a/residentevil2remake/data/leon/a/regions.json
+++ b/residentevil2remake/data/leon/a/regions.json
@@ -32,7 +32,7 @@
         "zone_id": 1
     },
     {
-        "name": "West Hallway",
+        "name": "Southwest Hallway",
         "zone_id": 1
     },
     {
@@ -105,6 +105,10 @@
     },
     {
         "name": "Shower Room",
+        "zone_id": 1
+    },
+    {
+        "name": "STARS Office Hallway",
         "zone_id": 1
     },
     {

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -358,7 +358,7 @@
     },
     {
         "name": "Downed Zombie 2F",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
         "item_object": "sm70_111",
@@ -367,7 +367,7 @@
     },
     {
         "name": "By Coffee Vending Machine",
-        "region": "West Hallway 1F",
+        "region": "West Hallway 2F",
         "original_item": "Red Herb",
         "condition": {},    
         "item_object": "sm70_002",
@@ -412,7 +412,7 @@
     },
     {
         "name": "Couch",
-        "region": "West Hallway 2F",
+        "region": "STARS Office Hallway",
         "original_item": "Shotgun Shells",
         "condition": {},    
         "item_object": "sm70_101",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -357,7 +357,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom"
     },
     {
-        "name": "Downed Zombie 2F",
+        "name": "Downed Zombie",
         "region": "West Hallway 2F",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    

--- a/residentevil2remake/data/leon/b/region_connections.json
+++ b/residentevil2remake/data/leon/b/region_connections.json
@@ -84,17 +84,17 @@
     },
     {
         "from": "Reception - RPD",
-        "to": "West Hallway"
+        "to": "Southwest Hallway"
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Records Room",
         "condition": {
             "items": ["Club Key"]
         }
     },
     { 
-        "from": "West Hallway",
+        "from": "Southwest Hallway",
         "to": "Operations Room",
         "condition": {}
     },
@@ -139,6 +139,11 @@
     },
     { 
         "from": "West Hallway 1F",
+        "to": "West Hallway 2F",
+        "condition": {}
+    },
+    { 
+        "from": "West Hallway 2F",
         "to": "Shower Room",
         "condition": {
             "items": ["Valve Handle"]
@@ -146,11 +151,11 @@
     },
     { 
         "from": "Shower Room",
-        "to": "West Hallway 2F",
+        "to": "STARS Office Hallway",
         "condition": {}
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "STARS Office",
         "condition": {}
     },
@@ -162,14 +167,14 @@
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Linen Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "West Hallway 2F",
+        "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
         "condition": {
             "items": ["Battery"]

--- a/residentevil2remake/data/leon/b/regions.json
+++ b/residentevil2remake/data/leon/b/regions.json
@@ -68,7 +68,7 @@
         "zone_id": 1
     },
     {
-        "name": "West Hallway",
+        "name": "Southwest Hallway",
         "zone_id": 1
     },
     {
@@ -101,6 +101,10 @@
     },
     {
         "name": "Shower Room",
+        "zone_id": 1
+    },
+    {
+        "name": "STARS Office Hallway",
         "zone_id": 1
     },
     {


### PR DESCRIPTION
Adds the `Orphanage` typewriter back in as a fail-safe if items were missed, and changes location names/region+connections to reflect the suggestion by @cyberlennoxxx