### PR TITLE
Small change to try and fix UT issue

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1175,7 +1175,7 @@
         "original_item": "Red Herb",
         "force_item": "Boxed Electronic Part 2",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Diamond Key"]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1292,7 +1292,7 @@
         "original_item": "Red Herb",
         "force_item": "Boxed Electronic Part 2",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Diamond Key"]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",


### PR DESCRIPTION
Try and correct a UT tracker issue, as it thought you could access `After Helicopter Crash` but not the `Roof` in certain cases as it was.