### PR TITLE
Changes to Wristband and Trophy Items.

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1932,7 +1932,7 @@
     {
         "name": "Table in Middle of Lounge",
         "region": "Lounge - Labs",
-        "original_item": "Trophy",
+        "original_item": "Trophy A",
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",

--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1730,7 +1730,7 @@
     {
         "name": "Sherry's Wristband",
         "region": "Cable Car Platform",
-        "original_item": "ID Wristband - Visitor",
+        "original_item": "Wristband - Visitor",
         "condition": {},    
         "item_object": "CFPlay2_CF705_01",
         "parent_object": "",
@@ -1803,7 +1803,7 @@
     {
         "name": "Sleeping Pod",
         "region": "Nap Room",
-        "original_item": "ID Wristband - General Staff",
+        "original_item": "Wristband - General Staff",
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
@@ -2013,8 +2013,8 @@
     {
         "name": "Downed Employee",
         "region": "Greenhouse",
-        "original_item": "ID Wristband - Senior Staff",
-        "force_item": "ID Wristband - Senior Staff",
+        "original_item": "Wristband - Senior Staff",
+        "force_item": "Wristband - Senior Staff",
         "condition": {
             "items": ["Signal Modulator"]
         },    
@@ -2269,7 +2269,7 @@
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 
-                "ID Wristband - General Staff", "ID Wristband - Senior Staff", "Signal Modulator",
+                "Wristband - General Staff", "Wristband - Senior Staff", "Signal Modulator",
                 "Joint Plug"
             ]
         },

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -465,7 +465,7 @@
         "from": "Reception - Labs",
         "to": "Main Shaft",
         "condition": {
-            "items": ["ID Wristband - General Staff"]
+            "items": ["Wristband - General Staff"]
         }
     },
     { 
@@ -529,7 +529,7 @@
         "from": "Main Shaft",
         "to": "Biotesting Lab",
         "condition": {
-            "items": ["Signal Modulator", "ID Wristband - Senior Staff"]
+            "items": ["Signal Modulator", "Wristband - Senior Staff"]
         }
     },
     { 

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -2094,7 +2094,7 @@
 	{
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
-        "original_item": "Trophy",
+        "original_item": "Trophy B",
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1847,7 +1847,7 @@
     {
         "name": "Sherry's Wristband",
         "region": "Security Room",
-        "original_item": "ID Wristband - Visitor",
+        "original_item": "Wristband - Visitor",
         "condition": {},    
         "item_object": "CFPlay2_CF705_01",
         "parent_object": "",
@@ -1920,7 +1920,7 @@
     {
         "name": "Sleeping Pod",
         "region": "Nap Room",
-        "original_item": "ID Wristband - General Staff",
+        "original_item": "Wristband - General Staff",
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
@@ -2130,8 +2130,8 @@
     {
         "name": "Downed Employee",
         "region": "Greenhouse",
-        "original_item": "ID Wristband - Senior Staff",
-        "force_item": "ID Wristband - Senior Staff",
+        "original_item": "Wristband - Senior Staff",
+        "force_item": "Wristband - Senior Staff",
         "condition": {
             "items": ["Signal Modulator"]
         },     
@@ -2413,7 +2413,7 @@
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 
-                "ID Wristband - General Staff", "ID Wristband - Senior Staff", "Signal Modulator",
+                "Wristband - General Staff", "Wristband - Senior Staff", "Signal Modulator",
                 "Joint Plug"
             ]
         },

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -493,7 +493,7 @@
         "from": "Reception - Labs",
         "to": "Main Shaft",
         "condition": {
-            "items": ["ID Wristband - General Staff"]
+            "items": ["Wristband - General Staff"]
         }
     },
     { 
@@ -557,7 +557,7 @@
         "from": "Main Shaft",
         "to": "Biotesting Lab",
         "condition": {
-            "items": ["Signal Modulator", "ID Wristband - Senior Staff"]
+            "items": ["Signal Modulator", "Wristband - Senior Staff"]
         }
     },
     { 

--- a/residentevil2remake/data/claire/items.json
+++ b/residentevil2remake/data/claire/items.json
@@ -205,8 +205,15 @@
     },
     {
         "type": "Key",
-        "name": "Trophy",
+        "name": "Trophy A",
         "decimal": "191",
+        "count": 1,
+        "progression": 1
+    },
+    {
+        "type": "Key",
+        "name": "Trophy B",
+        "decimal": "190",
         "count": 1,
         "progression": 1
     },

--- a/residentevil2remake/data/claire/items.json
+++ b/residentevil2remake/data/claire/items.json
@@ -173,7 +173,7 @@
     },
     {
         "type": "Key",
-        "name": "ID Wristband - Visitor",
+        "name": "Wristband - Visitor",
         "groups": ["wristband", "bracelet", "id"],
         "decimal": "200",
         "count": 1,
@@ -181,7 +181,7 @@
     },
     {
         "type": "Key",
-        "name": "ID Wristband - General Staff",
+        "name": "Wristband - General Staff",
         "groups": ["wristband", "bracelet", "id"],
         "decimal": "201",
         "count": 1,
@@ -189,7 +189,7 @@
     },
     {
         "type": "Key",
-        "name": "ID Wristband - Senior Staff",
+        "name": "Wristband - Senior Staff",
         "groups": ["wristband", "bracelet", "id"],
         "decimal": "202",
         "count": 1,

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1984,7 +1984,7 @@
     {
         "name": "Table in Middle of Lounge",
         "region": "Lounge - Labs",
-        "original_item": "Trophy",
+        "original_item": "Trophy A",
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -2059,7 +2059,7 @@
 	{
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
-        "original_item": "Trophy",
+        "original_item": "Trophy B",
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",

--- a/residentevil2remake/data/leon/items.json
+++ b/residentevil2remake/data/leon/items.json
@@ -197,8 +197,15 @@
     },
     {
         "type": "Key",
-        "name": "Trophy",
+        "name": "Trophy A",
         "decimal": "191",
+        "count": 1,
+        "progression": 1
+    },
+    {
+        "type": "Key",
+        "name": "Trophy B",
+        "decimal": "190",
         "count": 1,
         "progression": 1
     },


### PR DESCRIPTION
Change `ID Wristband` to just `Wristband` during Claire Scenario as to avoid conflict with Leon Scenario.

Changes `Trophy` to `Trophy A` and adds `Trophy B` so as to give proper item during playthroughs.