### PR TITLE
Changes `Trophy` Item

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1932,7 +1932,7 @@
     {
         "name": "Table in Middle of Lounge",
         "region": "Lounge - Labs",
-        "original_item": "Trophy",
+        "original_item": "Trophy A",
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -2094,7 +2094,7 @@
 	{
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
-        "original_item": "Trophy",
+        "original_item": "Trophy B",
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",

--- a/residentevil2remake/data/claire/items.json
+++ b/residentevil2remake/data/claire/items.json
@@ -205,8 +205,15 @@
     },
     {
         "type": "Key",
-        "name": "Trophy",
+        "name": "Trophy A",
         "decimal": "191",
+        "count": 1,
+        "progression": 1
+    },
+    {
+        "type": "Key",
+        "name": "Trophy B",
+        "decimal": "190",
         "count": 1,
         "progression": 1
     },

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1984,7 +1984,7 @@
     {
         "name": "Table in Middle of Lounge",
         "region": "Lounge - Labs",
-        "original_item": "Trophy",
+        "original_item": "Trophy A",
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -2059,7 +2059,7 @@
 	{
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
-        "original_item": "Trophy",
+        "original_item": "Trophy B",
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",

--- a/residentevil2remake/data/leon/items.json
+++ b/residentevil2remake/data/leon/items.json
@@ -197,8 +197,15 @@
     },
     {
         "type": "Key",
-        "name": "Trophy",
+        "name": "Trophy A",
         "decimal": "191",
+        "count": 1,
+        "progression": 1
+    },
+    {
+        "type": "Key",
+        "name": "Trophy B",
+        "decimal": "190",
         "count": 1,
         "progression": 1
     },


### PR DESCRIPTION
Changes `Trophy` to `Trophy A` and adds `Trophy B` as an item so as to give the proper one out when playing different scenarios.