### PR TITLE
Prevent Sewers Key from showing up after Sewers

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1769,6 +1769,7 @@
         "item_object": "CFPlay2_CF705_01",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Scenario/S05_0000/Claire_S05_0000/SherryRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1778,7 +1779,8 @@
         "condition": {},    
         "item_object": "WP4100",
         "parent_object": "WP4100_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/Sherry Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/Sherry Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie at Entrance",
@@ -1787,7 +1789,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Booth by Door",
@@ -1796,7 +1799,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Coffee and Candy Counter",
@@ -1805,7 +1809,8 @@
         "condition": {},    
         "item_object": "sm70_109",
         "parent_object": "sm70_109_Spark",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/DiningRoomCorridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/DiningRoomCorridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1814,7 +1819,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1823,7 +1829,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "wp4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table with Lamp",
@@ -1832,7 +1839,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod",
@@ -1841,7 +1849,8 @@
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -1850,7 +1859,8 @@
         "condition": {},    
         "item_object": "sm71_919",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom/LockerT01_sm71_919_SparkParts"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom/LockerT01_sm71_919_SparkParts",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod 2",
@@ -1861,7 +1871,8 @@
         },    
         "item_object": "sm74_200",
         "parent_object": "sm74_200_Sidepack",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -1870,7 +1881,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_002_Greenherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Behind Front Desk",
@@ -1879,7 +1891,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_Gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Ivy Room Before",
@@ -1888,7 +1901,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/CorridorA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/CorridorA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Middle Desk",
@@ -1897,7 +1911,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_flashgrenade_lab_1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Dispersal Machine",
@@ -1907,6 +1922,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1916,7 +1932,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_redherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Ladder",
@@ -1925,7 +1942,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1934,7 +1952,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1943,7 +1962,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Down Ladder Before Lounge",
@@ -1952,7 +1972,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Bench By Entrance",
@@ -1961,7 +1982,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table in Middle of Lounge",
@@ -1970,7 +1992,8 @@
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Benches Across the Room",
@@ -1979,7 +2002,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001_GreenHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Door",
@@ -1988,7 +2012,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -1997,7 +2022,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Signal Modulator Panel",
@@ -2006,7 +2032,8 @@
         "condition": {},    
         "item_object": "sm73_424",
         "parent_object": "sm73_424_MenteTool_1st",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Across from Robot Arm",
@@ -2015,7 +2042,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Left of Door",
@@ -2024,7 +2052,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "On Cart By Laptop",
@@ -2033,7 +2062,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Shelves Left of Typewriter",
@@ -2042,7 +2072,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Employee",
@@ -2054,7 +2085,8 @@
         },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie",
@@ -2063,7 +2095,8 @@
         "condition": {},    
         "item_object": "sm73_438",
         "parent_object": "sm73_438_VideoTape",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie 2",
@@ -2072,7 +2105,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Operating Area",
@@ -2081,7 +2115,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Sanitation Spray",
@@ -2090,7 +2125,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/Corridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/Corridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Cart By Doorway",
@@ -2099,7 +2135,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Desk",
@@ -2108,7 +2145,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker by Desk",
@@ -2117,7 +2155,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 1",
@@ -2126,7 +2165,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_01",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "First of Two Flashbangs",
@@ -2135,7 +2175,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Left of Entrance",
@@ -2144,7 +2185,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Left of Entrance",
@@ -2153,7 +2195,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Right of Entrance",
@@ -2162,7 +2205,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_03",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 2",
@@ -2171,7 +2215,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_02",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Second of Two Flashbangs",
@@ -2180,7 +2225,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 1",
@@ -2189,7 +2235,8 @@
         "condition": {},    
         "item_object": "sm70_109",
         "parent_object": "sm70_109_Cartridge",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Right of Entrance",
@@ -2198,7 +2245,8 @@
         "condition": {},    
         "item_object": "sm70_112",
         "parent_object": "sm70_112_MagnumBClaire",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 2",
@@ -2207,7 +2255,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Annette's Wristband",
@@ -2217,6 +2266,7 @@
         "item_object": "CFPlay_EV750",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Scenario/S05_0200/Claire_S05_0200/GuradRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -2226,7 +2276,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Elevator 2",
@@ -2235,7 +2286,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Start of Ivy Room",
@@ -2244,7 +2296,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Ladder on Ground",
@@ -2253,7 +2306,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Ladder on Ground",
@@ -2262,7 +2316,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Inside Turntable",
@@ -2271,7 +2326,8 @@
         "condition": {},    
         "item_object": "sm73_418",
         "parent_object": "sm73_418_2wakuItem",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle By Item Box",
@@ -2280,7 +2336,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_102_RHerb",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Turntable Control Room",
@@ -2290,6 +2347,7 @@
         "item_object": "WP4700",
         "parent_object": "wp4700_GatoringuGun",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/LocationFsm_LaboratoryUndermost/S05_0400/Claire_S05_0400/Enemy",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
 

--- a/residentevil2remake/data/claire/a/locations_hardcore.json
+++ b/residentevil2remake/data/claire/a/locations_hardcore.json
@@ -123,7 +123,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Narea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     { 
         "name": "Front Desk", 
@@ -132,7 +133,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Tarea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Beside Typewriter",
@@ -141,7 +143,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Garea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Typewriter",
@@ -150,7 +153,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
     	"name": "Side Table",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1876,6 +1876,7 @@
         "item_object": "CFPlay2_CF705_01",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Scenario/S05_0000/Claire_S05_0000/SherryRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1885,7 +1886,8 @@
         "condition": {},
         "item_object": "WP4100",
         "parent_object": "WP4100_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/Sherry Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/Sherry Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie at Entrance",
@@ -1894,7 +1896,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Booth by Door",
@@ -1903,7 +1906,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Coffee and Candy Counter",
@@ -1912,7 +1916,8 @@
         "condition": {},    
         "item_object": "sm70_109",
         "parent_object": "sm70_109_Spark",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/DiningRoomCorridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/DiningRoomCorridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1921,7 +1926,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1930,7 +1936,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "wp4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table with Lamp",
@@ -1939,7 +1946,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod",
@@ -1948,7 +1956,8 @@
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -1957,7 +1966,8 @@
         "condition": {},    
         "item_object": "sm71_919",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom/LockerT01_sm71_919_SparkParts"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/NapRoom/LockerT01_sm71_919_SparkParts",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod 2",
@@ -1968,7 +1978,8 @@
         },    
         "item_object": "sm74_200",
         "parent_object": "sm74_200_Sidepack",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Next to Soldier",
@@ -1977,7 +1988,8 @@
         "condition": {},    
         "item_object": "sm73_424",
         "parent_object": "sm73_424_MenteTool_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -1986,7 +1998,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_002_Greenherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Behind Front Desk",
@@ -1995,7 +2008,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_Gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Ivy Room Before",
@@ -2004,7 +2018,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/CorridorA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/CorridorA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Middle Desk",
@@ -2013,7 +2028,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_flashgrenade_lab_1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Dispersal Machine",
@@ -2023,6 +2039,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -2032,7 +2049,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_redherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Ladder",
@@ -2041,7 +2059,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -2050,7 +2069,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -2059,7 +2079,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Down Ladder Before Lounge",
@@ -2068,7 +2089,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Bench By Entrance",
@@ -2077,7 +2099,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Benches Across the Room",
@@ -2086,7 +2109,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001_GreenHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Door",
@@ -2095,7 +2119,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -2104,7 +2129,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Across from Robot Arm",
@@ -2113,7 +2139,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Table near Entrance",
@@ -2122,7 +2149,8 @@
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Left of Door",
@@ -2131,7 +2159,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "On Cart By Laptop",
@@ -2140,7 +2169,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Shelves Left of Typewriter",
@@ -2149,7 +2179,8 @@
         "condition": {},    
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Employee",
@@ -2161,7 +2192,8 @@
         },     
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie",
@@ -2170,7 +2202,8 @@
         "condition": {},    
         "item_object": "sm73_438",
         "parent_object": "sm73_438_VideoTape",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie 2",
@@ -2179,7 +2212,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Operating Area",
@@ -2188,7 +2222,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Sanitation Spray",
@@ -2197,7 +2232,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/Corridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/Corridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Cart By Doorway",
@@ -2206,7 +2242,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Desk",
@@ -2215,7 +2252,8 @@
         "condition": {},    
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ClaireYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker by Desk",
@@ -2224,7 +2262,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 1",
@@ -2233,7 +2272,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_01_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "First of Two Flashbangs",
@@ -2242,7 +2282,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Left of Entrance",
@@ -2251,7 +2292,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Left of Entrance",
@@ -2260,7 +2302,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Right of Entrance",
@@ -2269,7 +2312,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_03_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 2",
@@ -2278,7 +2322,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_02_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Second of Two Flashbangs",
@@ -2287,7 +2332,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 1",
@@ -2296,7 +2342,8 @@
         "condition": {},    
         "item_object": "sm70_109",
         "parent_object": "sm70_109_Cartridge",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Right of Entrance",
@@ -2305,7 +2352,8 @@
         "condition": {},    
         "item_object": "sm70_112",
         "parent_object": "sm70_112_MagnumBClaire",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 2",
@@ -2314,7 +2362,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Annette's Wristband",
@@ -2324,6 +2373,7 @@
         "item_object": "CFPlay_EV750",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Scenario/S05_0200/Claire_S05_0200/GuradRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -2333,7 +2383,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Elevator 2",
@@ -2342,7 +2393,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Start of Ivy Room",
@@ -2351,7 +2403,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Ladder on Ground",
@@ -2360,7 +2413,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Ladder on Ground",
@@ -2369,7 +2423,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Inside Turntable",
@@ -2378,7 +2433,8 @@
         "condition": {},    
         "item_object": "sm73_418",
         "parent_object": "sm73_418_2wakuItem",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle By Item Box",
@@ -2387,7 +2443,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_102_RHerb",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Claire_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Turntable Control Room",
@@ -2397,6 +2454,7 @@
         "item_object": "WP4700",
         "parent_object": "wp4700_GatoringuGun",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/LocationFsm_LaboratoryUndermost/S05_0400/Claire_S05_0400/Enemy",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
 	{
@@ -2406,7 +2464,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206-2_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "On Floor by Barrels",
@@ -2415,7 +2474,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Stabbed into Cargo",
@@ -2424,7 +2484,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 
     {

--- a/residentevil2remake/data/claire/b/locations_hardcore.json
+++ b/residentevil2remake/data/claire/b/locations_hardcore.json
@@ -132,7 +132,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Narea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     { 
         "name": "Front Desk", 
@@ -141,7 +142,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Tarea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Beside Typewriter",
@@ -150,7 +152,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Garea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Typewriter",
@@ -159,7 +162,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Next to Gunpowder",
@@ -168,7 +172,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Main Desk 1",

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1797,6 +1797,7 @@
         "item_object": "WW_WarpToLabo",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/LocationFsm_WasteWater/S04_0200/startLever_cableCar",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1806,7 +1807,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_shotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/SherryRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/SherryRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie at Entrance",
@@ -1815,7 +1817,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Booth by Door",
@@ -1824,7 +1827,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Coffee and Candy Counter",
@@ -1833,7 +1837,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Fuel",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/DiningRoomCorridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/DiningRoomCorridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1842,7 +1847,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1851,7 +1857,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "wp4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table with Lamp",
@@ -1860,7 +1867,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_ShotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod",
@@ -1869,7 +1877,8 @@
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -1878,7 +1887,8 @@
         "condition": {},    
         "item_object": "sm71_918",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom/LockerT01_sm71_918_FireLauncherParts"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom/LockerT01_sm71_918_FireLauncherParts",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod 2",
@@ -1889,7 +1899,8 @@
         },    
         "item_object": "sm74_200",
         "parent_object": "sm74_200_Sidepack",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -1898,7 +1909,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_002_Greenherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Behind Front Desk",
@@ -1907,7 +1919,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_Gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Ivy Room Before",
@@ -1916,7 +1929,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/CorridorA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/CorridorA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Middle Desk",
@@ -1925,7 +1939,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_flashgrenade_lab_1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Dispersal Machine",
@@ -1935,6 +1950,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1944,7 +1960,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_redherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Ladder",
@@ -1953,7 +1970,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1962,7 +1980,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1971,7 +1990,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Down Ladder Before Lounge",
@@ -1980,7 +2000,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Bench By Entrance",
@@ -1989,7 +2010,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_ShotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table in Middle of Lounge",
@@ -1998,7 +2020,8 @@
         "condition": {},    
         "item_object": "sm73_426",
         "parent_object": "sm43_426_Kibori no Kuma_1st",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Benches Across the Room",
@@ -2007,7 +2030,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001_GreenHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Door",
@@ -2016,7 +2040,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -2025,7 +2050,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Signal Modulator Panel",
@@ -2034,7 +2060,8 @@
         "condition": {},    
         "item_object": "sm73_424",
         "parent_object": "sm73_424_MenteTool_1st",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Across from Robot Arm",
@@ -2043,7 +2070,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Left of Door",
@@ -2052,7 +2080,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "On Cart By Laptop",
@@ -2061,7 +2090,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Shelves Left of Typewriter",
@@ -2070,7 +2100,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Oil",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Employee",
@@ -2082,7 +2113,8 @@
         },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie",
@@ -2091,7 +2123,8 @@
         "condition": {},    
         "item_object": "sm73_438",
         "parent_object": "sm73_438_VideoTape",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie 2",
@@ -2100,7 +2133,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Operating Area",
@@ -2109,7 +2143,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Sanitation Spray",
@@ -2118,7 +2153,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/Corridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/Corridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Cart By Doorway",
@@ -2127,7 +2163,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Desk",
@@ -2136,7 +2173,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker by Desk",
@@ -2145,7 +2183,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 1",
@@ -2154,7 +2193,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_01",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "First of Two Flashbangs",
@@ -2163,7 +2203,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Left of Entrance",
@@ -2172,7 +2213,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Left of Entrance",
@@ -2181,7 +2223,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Right of Entrance",
@@ -2190,7 +2233,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_03",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 2",
@@ -2199,7 +2243,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100_handgunB_02",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Second of Two Flashbangs",
@@ -2208,7 +2253,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 1",
@@ -2217,7 +2263,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Fuel",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Right of Entrance",
@@ -2226,7 +2273,8 @@
         "condition": {},    
         "item_object": "sm70_103",
         "parent_object": "sm70_103_MagnumB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 2",
@@ -2235,7 +2283,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Voice Call",
@@ -2244,7 +2293,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Voice Call",
@@ -2253,7 +2303,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Start of Ivy Room",
@@ -2262,7 +2313,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Ladder at Mr X",
@@ -2271,7 +2323,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Ladder at Mr X",
@@ -2280,7 +2333,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle Table Item 1",
@@ -2289,7 +2343,8 @@
         "condition": {},    
         "item_object": "sm73_418",
         "parent_object": "sm73_418_2wakuItem",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle Table Item 2",
@@ -2298,7 +2353,8 @@
         "condition": {},    
         "item_object": "sm70_100",
         "parent_object": "sm70_100",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle By Item Box",
@@ -2307,7 +2363,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_102_RHerb",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Hit on Super Tyrant",
@@ -2317,6 +2374,7 @@
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
 

--- a/residentevil2remake/data/leon/a/locations_hardcore.json
+++ b/residentevil2remake/data/leon/a/locations_hardcore.json
@@ -114,7 +114,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Narea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -123,7 +124,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Tarea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Beside Typewriter",
@@ -132,7 +134,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Garea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Typewriter",
@@ -141,7 +144,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
     	"name": "Side Table",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1817,6 +1817,7 @@
         "item_object": "WW_WarpToLabo",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/LocationFsm_WasteWater/S04_0200/startLever_cableCar",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1826,7 +1827,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_shotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/SherryRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/SherryRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie at Entrance",
@@ -1835,7 +1837,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Booth by Door",
@@ -1844,7 +1847,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Coffee and Candy Counter",
@@ -1853,7 +1857,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Fuel",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/DiningRoomCorridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/DiningRoomCorridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1862,7 +1867,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -1871,7 +1877,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "wp4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/DiningRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table with Lamp",
@@ -1880,7 +1887,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_ShotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod",
@@ -1889,7 +1897,8 @@
         "condition": {},    
         "item_object": "sm73_423",
         "parent_object": "sm73_433_WristTagUpdater_Lv1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -1898,7 +1907,8 @@
         "condition": {},    
         "item_object": "sm71_918",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom/LockerT01_sm71_918_FireLauncherParts"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/StartArea/NapRoom/LockerT01_sm71_918_FireLauncherParts",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Sleeping Pod 2",
@@ -1909,7 +1919,8 @@
         },    
         "item_object": "sm74_200",
         "parent_object": "sm74_200_Sidepack",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Next to Soldier",
@@ -1918,7 +1929,8 @@
         "condition": {},    
         "item_object": "sm73_424",
         "parent_object": "sm73_424_MenteTool_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -1927,7 +1939,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_002_Greenherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Behind Front Desk",
@@ -1936,7 +1949,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_Gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/Lobby",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Ivy Room Before",
@@ -1945,7 +1959,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/CorridorA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/CorridorA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Middle Desk",
@@ -1954,7 +1969,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_flashgrenade_lab_1",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ControlRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Dispersal Machine",
@@ -1964,6 +1980,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
     {
@@ -1973,7 +1990,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_redherb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Ladder",
@@ -1982,7 +2000,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 1",
@@ -1991,7 +2010,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Location 2",
@@ -2000,7 +2020,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/ChemicalRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Down Ladder Before Lounge",
@@ -2009,7 +2030,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/UnderCollidor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Bench By Entrance",
@@ -2018,7 +2040,8 @@
         "condition": {},    
         "item_object": "sm70_101",
         "parent_object": "sm70_101_ShotgunB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Benches Across the Room",
@@ -2027,7 +2050,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001_GreenHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/RestArea",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Door",
@@ -2036,7 +2060,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotA"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotA",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker",
@@ -2045,7 +2070,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "ItemPositionsCollider",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotA/Locker03_HandgunB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Across from Robot Arm",
@@ -2054,7 +2080,8 @@
         "condition": {},    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Table near Entrance",
@@ -2063,7 +2090,8 @@
         "condition": {},    
         "item_object": "sm73_425",
         "parent_object": "sm43_425_Kibori no Kuma_2ndPlay",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/2ndPlay",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Left of Door",
@@ -2072,7 +2100,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "On Cart By Laptop",
@@ -2081,7 +2110,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_Knife",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Shelves Left of Typewriter",
@@ -2090,7 +2120,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Oil",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/TArea/DepotB",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Employee",
@@ -2102,7 +2133,8 @@
         },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie",
@@ -2111,7 +2143,8 @@
         "condition": {},    
         "item_object": "sm73_438",
         "parent_object": "sm73_438_VideoTape",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Downed Zombie 2",
@@ -2120,7 +2153,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Past Operating Area",
@@ -2129,7 +2163,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/P4ExperimentRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Sanitation Spray",
@@ -2138,7 +2173,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/Corridor"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/Corridor",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Cart By Doorway",
@@ -2147,7 +2183,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_GunpowderBig",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Desk",
@@ -2156,7 +2193,8 @@
         "condition": {},    
         "item_object": "sm70_207",
         "parent_object": "sm70_207_LeonYakueki",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Locker by Desk",
@@ -2165,7 +2203,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/GVirusRoom",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 1",
@@ -2174,7 +2213,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_01_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "First of Two Flashbangs",
@@ -2183,7 +2223,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Left of Entrance",
@@ -2192,7 +2233,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000_Spray",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Left of Entrance",
@@ -2201,7 +2243,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "1st Table Right of Entrance",
@@ -2210,7 +2253,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_03_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Table Right of Elevator 2",
@@ -2219,7 +2263,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111_handgunB_02_2nd",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Second of Two Flashbangs",
@@ -2228,7 +2273,8 @@
         "condition": {},    
         "item_object": "WP6300",
         "parent_object": "WP6300_FlashBan",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 1",
@@ -2237,7 +2283,8 @@
         "condition": {},    
         "item_object": "sm70_110",
         "parent_object": "sm70_110_Fuel",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "2nd Table Right of Entrance",
@@ -2246,7 +2293,8 @@
         "condition": {},    
         "item_object": "sm70_103",
         "parent_object": "sm70_103_MagnumB",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Leon_common/GArea/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Right Side of Room 2",
@@ -2255,7 +2303,8 @@
         "condition": {},    
         "item_object": "WP6200",
         "parent_object": "WP6200_Grenade",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/G_Area/G3Room",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Voice Call",
@@ -2264,7 +2313,8 @@
         "condition": {},    
         "item_object": "sm70_000",
         "parent_object": "sm70_000",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Voice Call",
@@ -2273,7 +2323,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Start of Ivy Room",
@@ -2282,7 +2333,8 @@
         "condition": {},    
         "item_object": "sm70_003",
         "parent_object": "sm70_003",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Ladder at Mr X",
@@ -2291,7 +2343,8 @@
         "condition": {},    
         "item_object": "sm70_001",
         "parent_object": "sm70_001",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "After Ladder at Mr X",
@@ -2300,7 +2353,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle Table Item",
@@ -2309,7 +2363,8 @@
         "condition": {},    
         "item_object": "sm73_418",
         "parent_object": "sm73_418_2wakuItem",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle Barrel Item",
@@ -2318,7 +2373,8 @@
         "condition": {},    
         "item_object": "sm70_111",
         "parent_object": "sm70_111",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Battle By Item Box",
@@ -2327,7 +2383,8 @@
         "condition": {},    
         "item_object": "sm70_002",
         "parent_object": "sm70_102_RHerb",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common/Leon_common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Final Hit on Super Tyrant",
@@ -2337,6 +2394,7 @@
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"],
         "randomized": 0
     },
 	{
@@ -2346,7 +2404,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206-2_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "On Floor by Barrels",
@@ -2355,7 +2414,8 @@
         "condition": {},    
         "item_object": "sm70_206",
         "parent_object": "sm70_206_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 	{
         "name": "Stabbed into Cargo",
@@ -2364,7 +2424,8 @@
         "condition": {},    
         "item_object": "WP4500",
         "parent_object": "WP4500_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
 
     {

--- a/residentevil2remake/data/leon/b/locations_hardcore.json
+++ b/residentevil2remake/data/leon/b/locations_hardcore.json
@@ -123,7 +123,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Narea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Front Desk",
@@ -132,7 +133,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Tarea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Beside Typewriter",
@@ -141,7 +143,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_Inkribbon_Garea",
-        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon"
+        "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/InkRibbon",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Boxes By Typewriter",
@@ -150,7 +153,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Next to Gunpowder",
@@ -159,7 +163,8 @@
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201_G5",
-        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common"
+        "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/LocationLevel_LaboratoryUndermost/Item/common",
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Main Desk 1",


### PR DESCRIPTION
Since backtracking to Sewers currently runs the risk of a softlock, Sewers Key shouldn't be randomized into any location after Sewers. This PR also gives the same treatment to T-Bar Handle, since that will also be randomized in a future PR that disables the T-Bar spot in Secret Room.