### PR TITLE
Randomize the T-Bar Handle once again

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1550,8 +1550,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1648,8 +1648,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1578,8 +1578,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1598,8 +1598,7 @@
         "condition": {},    
         "item_object": "sm73_411",
         "parent_object": "T_ji_crank",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem",
-        "randomized": 0
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
         "name": "Downstairs Location 1",


### PR DESCRIPTION
Originally didn't rando the T-Bar because using it in Secret Room early would softlock. So the client is going to remove the T-Bar interactable in Secret Room and make this rando-able again.