### PR TITLE
Helicopter logic fix, Lounge one-way door fix, some small logic fixes

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1209,7 +1209,7 @@
         "original_item": "Red Herb",
         "force_item": "Boxed Electronic Part 2",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Diamond Key"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Heart Key", "Diamond Key"]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",

--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1204,8 +1204,8 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FE/ChiefStore"
     },
     {
-        "name": "After Helicopter Crash",
-        "region": "East Hallway 2F",
+        "name": "Room with Helicopter Crash",
+        "region": "Roof",
         "original_item": "Red Herb",
         "force_item": "Boxed Electronic Part 2",
         "condition": {

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -135,15 +135,13 @@
     { 
         "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
-        "condition": {
-            "items": ["Battery"]
-        }
-    },
-    { 
-        "from": "Lounge - RPD",
-        "to": "Library",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Library",
+        "to": "Lounge - RPD",
+        "condition": {}
     },
     { 
         "from": "Main Hall",
@@ -233,7 +231,7 @@
         "from": "Main Hall",
         "to": "Secret Room",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key"]
         }
     },
     { 

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1311,12 +1311,12 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FE/ChiefStore"
     },
     {
-        "name": "After Helicopter Crash",
-        "region": "East Hallway 2F",
+        "name": "Room with Helicopter Crash",
+        "region": "Roof",
         "original_item": "Red Herb",
         "force_item": "Boxed Electronic Part 2",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Diamond Key"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Heart Key", "Diamond Key"]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -176,15 +176,13 @@
     { 
         "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
-        "condition": {
-            "items": ["Battery"]
-        }
-    },
-    { 
-        "from": "Lounge - RPD",
-        "to": "Library",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Library",
+        "to": "Lounge - RPD",
+        "condition": {}
     },
     { 
         "from": "Main Hall",
@@ -267,7 +265,7 @@
         "from": "Main Hall",
         "to": "Secret Room",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key"]
         }
     },
     { 

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1240,11 +1240,14 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorN"
     },
     {
-        "name": "After Helicopter Crash",
-        "region": "East Hallway 2F",
+        "name": "Room with Helicopter Crash",
+        "region": "Roof",
         "original_item": "Red Herb",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters", "Square Crank"]
+            "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Square Crank", "Fuse - Break Room Hallway"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Mechanic Jack Handle", "Fuse - Break Room Hallway"]
+            ]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",

--- a/residentevil2remake/data/leon/a/region_connections.json
+++ b/residentevil2remake/data/leon/a/region_connections.json
@@ -135,15 +135,13 @@
     { 
         "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
-        "condition": {
-            "items": ["Battery"]
-        }
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Lounge - RPD",
         "to": "Library",
-        "condition": {},
-        "limitation": "ONE_SIDED_DOOR"
+        "condition": {}
     },
     { 
         "from": "Main Hall",
@@ -232,7 +230,7 @@
         "from": "Main Hall",
         "to": "Secret Room",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key"]
         }
     },
     { 
@@ -320,7 +318,10 @@
         "from": "Side Stairs",
         "to": "Interrogation Room",
         "condition": {
-            "items": ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank", "Fuse - Break Room Hallway"]
+            "items": [
+                ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank", "Fuse - Break Room Hallway"],
+                ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Fuse - Break Room Hallway"]
+            ]
         }
     },
     { 
@@ -332,7 +333,10 @@
         "from": "Balcony",
         "to": "Roof",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Fuse - Break Room Hallway", "Square Crank"]
+            "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Fuse - Break Room Hallway", "Square Crank"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Fuse - Break Room Hallway", "Mechanic Jack Handle"]
+            ]
         }
     },
     { 

--- a/residentevil2remake/data/leon/a/region_connections.json
+++ b/residentevil2remake/data/leon/a/region_connections.json
@@ -139,8 +139,8 @@
         "limitation": "ONE_SIDED_DOOR"
     },
     { 
-        "from": "Lounge - RPD",
-        "to": "Library",
+        "from": "Library",
+        "to": "Lounge - RPD",
         "condition": {}
     },
     { 

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1260,11 +1260,14 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorN"
     },
     {
-        "name": "After Helicopter Crash",
-        "region": "East Hallway 2F",
+        "name": "Room with Helicopter Crash",
+        "region": "Roof",
         "original_item": "Red Herb",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters", "Square Crank"]
+            "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Square Crank"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Mechanic Jack Handle"]
+            ]
         },
         "item_object": "sm70_002",
         "parent_object": "sm70_002_RedHerb",

--- a/residentevil2remake/data/leon/b/region_connections.json
+++ b/residentevil2remake/data/leon/b/region_connections.json
@@ -176,15 +176,12 @@
     { 
         "from": "STARS Office Hallway",
         "to": "Lounge - RPD",
-        "condition": {
-            "items": ["Battery"]
-        }
+        "limitation": "ONE_SIDED_DOOR"
     },
 	{ 
-        "from": "Lounge - RPD",
-        "to": "Library",
-        "condition": {},
-        "limitation": "ONE_SIDED_DOOR"
+        "from": "Library",
+        "to": "Lounge - RPD",
+        "condition": {}
     },
     { 
         "from": "Main Hall",
@@ -263,7 +260,10 @@
         "from": "Side Stairs",
         "to": "Interrogation Room",
         "condition": {
-            "items": ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            "items": [
+                ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"],
+                ["Club Key", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
+            ]
         }
     },
     { 
@@ -275,7 +275,10 @@
         "from": "Balcony",
         "to": "Roof",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
+            ]
         }
     },
     { 
@@ -293,7 +296,7 @@
         "from": "Main Hall",
         "to": "Secret Room",
         "condition": {
-            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key", "Bolt Cutters"]
+            "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Spade Key"]
         }
     },
     { 


### PR DESCRIPTION
This PR does the following:

- Adds support for multiple sets of item requirements, where each set can by itself put a location in logic
- Renames the "After Helicopter Crash" check and moves it to the Roof region, which properly puts it behind the one-sided door from Roof to East Hall 2F
- Puts Helicopter check in logic for Leon scenarios with either Crank or Jack Handle
- Removes requirement for Jack Handle for Claire scenarios to get Helicopter check (since Chief's Office is required to backtrack, anyways)
- Removes requirement for Bolt Cutters to get to Secret Room
- Puts the RPD Lounge one-sided door on the correct door (the STARS Hallway one) and connects from Library to Lounge

I think that's it?