### PR TITLE
All Safety Deposit lockers that require a Spare Key should require both

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -141,7 +141,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Gunpowder",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder_Locker102",
@@ -183,7 +183,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Flame Rounds",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB_Locker208",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -206,7 +206,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Gunpowder",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder_Locker102",
@@ -248,7 +248,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Flame Rounds",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },
         "item_object": "sm70_108",
         "parent_object": "sm70_108_FireB_Locker208",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -206,7 +206,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Gunpowder",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },    
         "item_object": "sm70_205",
         "parent_object": "sm70_205_gunpowder_Locker102",
@@ -248,7 +248,7 @@
         "region": "Safety Deposit Room",
         "original_item": "Shotgun Shells",
         "condition": {
-            "items": ["Spare Key"]
+            "items": ["Spare Key", "Spare Key"]
         },
         "item_object": "sm70_101",
         "parent_object": "sm70_108_ShotgunB_Locker208",


### PR DESCRIPTION
About 6 months ago, there was a lot of conversation about the Spare Keys. Essentially, the conclusion of that conversation was: "If the player can hardlock themselves by using the spare key in the wrong slot, then the rando should only put the location in logic when the longer path (avoiding the hardlock) happens." Which I agreed with. 

Conversation from here: https://discord.com/channels/1085716850370957462/1096638934857031770/1231286543734276229

So this PR makes all of the Safety Deposit lockers that only required 1 Spare Key instead require both Spare Keys, as they should have following that convo.