### PR TITLE
Change Location Names and Fix Errors.. for Poptrackering!!

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -411,7 +411,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 1",
+        "name": "Northeastern Desk",
         "region": "STARS Office",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -420,7 +420,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 2",
+        "name": "Box Between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -429,7 +429,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 3",
+        "name": "First Aid On Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -438,7 +438,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 4",
+        "name": "Southeastern Desk",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -456,7 +456,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Location 1",
+        "name": "Towel Rack",
         "region": "Linen Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -465,7 +465,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/LinenRoom"
     },
     {
-        "name": "Location 2",
+        "name": "Washing Machine",
         "region": "Linen Room",
         "original_item": "Spare Key",
         "condition": {},    
@@ -795,7 +795,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/UnderGoddes"
     },
     {
-        "name": "Location 1",
+        "name": "Underneath Staircase",
         "region": "Underground Stairs",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -804,7 +804,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 2",
+        "name": "Cabinet",
         "region": "Underground Stairs",
         "original_item": "Suppressor - MQ 11",
         "condition": {
@@ -815,7 +815,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_claire"
     },
     {
-        "name": "Location 1",
+        "name": "Northwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -824,7 +824,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 2",
+        "name": "Northwest 2",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -833,7 +833,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 3",
+        "name": "Northwest 3",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -842,7 +842,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 4",
+        "name": "Southwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -851,7 +851,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 5",
+        "name": "Southwest 2",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -860,7 +860,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Location 6",
+        "name": "Southeast 1",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -869,7 +869,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 7",
+        "name": "Southeast 2",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -878,7 +878,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Upstairs Room Location 1",
+        "name": "Staff Room Floor",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -887,7 +887,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Upstairs Room Locker",
+        "name": "Staff Room Locker",
         "region": "Machinery Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -925,7 +925,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Location 2",
+        "name": "Cart Inside Range",
         "region": "Firing Range",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -965,7 +965,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Location 2",
+        "name": "Baskets Near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1002,7 +1002,7 @@
     },
     {
         "name": "Locker",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "Shoulder Stock - GM 79",
         "condition": {
             "items": ["Diamond Key"]
@@ -1013,7 +1013,7 @@
     },
     {
         "name": "Boxes Next to Table",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {
             "items": ["Diamond Key"]
@@ -1024,7 +1024,7 @@
     },
     {
         "name": "Corner of Room on Ground",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "Blue Herb",
         "condition": {
             "items": ["Diamond Key"]
@@ -1110,7 +1110,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/InterrogationRoom"
     },
     {
-        "name": "Location 1",
+        "name": "Table",
         "region": "Interrogation Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1128,7 +1128,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor"
     },
     {
-        "name": "3F Locker 1",
+        "name": "South Locker",
         "region": "Side Stairs",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1137,7 +1137,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_WP6300_FlashBan"
     },
     {
-        "name": "3F Locker 2",
+        "name": "West Locker",
         "region": "Side Stairs",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1146,7 +1146,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_sm70_100_HandgunB"
     },
     {
-        "name": "Shelves 1",
+        "name": "North Shelves",
         "region": "East Storage Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1164,7 +1164,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/3FDepot"
     },
     {
-        "name": "Shelves 2",
+        "name": "Southeast Shelves",
         "region": "East Storage Room",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -1441,7 +1441,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Claire_common/Mugnum_Claire"
     },
     {
-        "name": "Table Location 1",
+        "name": "On Table 1",
         "region": "Water Injection Chamber",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1450,7 +1450,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder_BIG"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1567,7 +1567,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location 1",
+        "name": "Downstairs Location",
         "region": "Treatment Pool Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1666,7 +1666,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/SubMachineGun"
     },
     {
-        "name": "Shelves 1",
+        "name": "Shelves",
         "region": "Supplies Storage Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -1826,7 +1826,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "On Bench",
         "region": "Kitchen",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1836,7 +1836,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Near Sinks",
         "region": "Kitchen",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1959,7 +1959,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "Desk",
         "region": "Drug Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1969,7 +1969,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Downed Scientist",
         "region": "Drug Testing Lab",
         "original_item": "Hand Grenade",
         "condition": {},    

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -266,13 +266,13 @@
     },
     { 
         "from": "Parking Garage",
-        "to": "Elevator Controls Room",
+        "to": "Elevator Control Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "Elevator Controls Room",
+        "from": "Elevator Control Room",
         "to": "Chief's Office",
         "condition": {}
     },

--- a/residentevil2remake/data/claire/a/regions.json
+++ b/residentevil2remake/data/claire/a/regions.json
@@ -201,7 +201,7 @@
         "zone_id": 2
     },
     {
-        "name": "Elevator Controls Room",
+        "name": "Elevator Control Room",
         "zone_id": 2
     },
     

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -476,7 +476,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 1",
+        "name": "Northeastern Desk",
         "region": "STARS Office",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -485,7 +485,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 2",
+        "name": "Box Between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -494,7 +494,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 3",
+        "name": "First Aid On Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -503,7 +503,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 4",
+        "name": "Southeastern Desk",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -530,7 +530,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Location 1",
+        "name": "Towel Rack",
         "region": "Linen Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -539,7 +539,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/LinenRoom"
     },
     {
-        "name": "Location 2",
+        "name": "Washing Machine",
         "region": "Linen Room",
         "original_item": "Spare Key",
         "condition": {},    
@@ -839,7 +839,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/UnderGoddes"
     },
     {
-        "name": "Location 1",
+        "name": "Underneath Staircase",
         "region": "Underground Stairs",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -848,7 +848,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 2",
+        "name": "Cabinet",
         "region": "Underground Stairs",
         "original_item": "Suppressor - MQ 11",
         "condition": {
@@ -859,7 +859,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_claire"
     },
     {
-        "name": "Location 1",
+        "name": "Northwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -868,7 +868,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 2",
+        "name": "Northwest 2",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -877,7 +877,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 3",
+        "name": "Northwest 3",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -886,7 +886,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 4",
+        "name": "Southwest 1",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -895,7 +895,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 5",
+        "name": "Southwest 2",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -904,7 +904,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Location 6",
+        "name": "Southeast 1",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -913,7 +913,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 7",
+        "name": "Southeast 2",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -922,7 +922,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Upstairs Room Location 1",
+        "name": "Staff Room Floor",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -931,7 +931,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Upstairs Room Locker",
+        "name": "Staff Room Locker",
         "region": "Machinery Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -969,7 +969,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Location 2",
+        "name": "Cart Inside Range",
         "region": "Firing Range",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -1009,7 +1009,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Location 2",
+        "name": "Baskets Near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1046,7 +1046,7 @@
     },
 	{
         "name": "Locker",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "Shoulder Stock - GM 79",
         "condition": {
             "items": ["Diamond Key"]
@@ -1057,7 +1057,7 @@
     },
     {
         "name": "Boxes Next to Table",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {
             "items": ["Diamond Key"]
@@ -1068,7 +1068,7 @@
     },
 	{
         "name": "Corner of Room on Ground",
-        "region": "Parking Garage",
+        "region": "Elevator Control Room",
         "original_item": "Blue Herb",
         "condition": {
             "items": ["Diamond Key"]
@@ -1127,69 +1127,6 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/3FE/3FClaireRoom"
     },
     {
-        "name": "Shelves",
-        "region": "Break Room Hallway",
-        "original_item": "Flame Rounds",
-        "condition": {},    
-        "item_object": "sm70_108",
-        "parent_object": "CLAIRE_sm70_108_Fire",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/CorriderC"
-    },
-    {
-        "name": "Stuck in Wall",
-        "region": "Break Room Hallway",
-        "original_item": "Combat Knife",
-        "condition": {},    
-        "item_object": "WP4500",
-        "parent_object": "WP4500_Knife",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/CorriderC"
-    },
-    {
-        "name": "Table",
-        "region": "Break Room",
-        "original_item": "Blue Herb",
-        "condition": {},    
-        "item_object": "sm70_003",
-        "parent_object": "sm70_003_BlueHerb",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
-    },
-    {
-        "name": "Locker 1",
-        "region": "Break Room",
-        "original_item": "High-Grade Gunpowder - White",
-        "condition": {},    
-        "item_object": "sm70_208",
-        "parent_object": "ItemPositions_NormalLocker_1FE_restroom1",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/NightDutyRoom/Locker_sm70_208_ClaireYakueki"
-    },
-    {
-        "name": "Locker 2",
-        "region": "Break Room",
-        "original_item": "Large-Caliber Handgun Ammo",
-        "condition": {},    
-        "item_object": "sm70_111",
-        "parent_object": "ItemPositions_NormalLocker_1FE_restroom2",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom/Locker_NightDutyRoomB_sm70_100_HandgunB"
-    },
-    {
-        "name": "Sink",
-        "region": "Break Room",
-        "original_item": "Submachine Gun Ammo",
-        "condition": {},    
-        "item_object": "sm70_102",
-        "parent_object": "sm70_102_machinegunB",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/NightDutyRoom"
-    },
-    {
-        "name": "Chair",
-        "region": "Break Room",
-        "original_item": "Fuse - Main Hall",
-        "condition": {},    
-        "item_object": "sm73_723",
-        "parent_object": "sm73_723_fuse2",
-        "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
-    },
-    {
         "name": "Locker",
         "region": "Side Stairs",
         "original_item": "High-Grade Gunpowder - White",
@@ -1217,7 +1154,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/InterrogationRoom"
     },
     {
-        "name": "Location 1",
+        "name": "Table",
         "region": "Interrogation Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1235,7 +1172,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor"
     },
     {
-        "name": "3F Locker 1",
+        "name": "South Locker",
         "region": "Side Stairs",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1244,7 +1181,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_WP6300_FlashBan"
     },
     {
-        "name": "3F Locker 2",
+        "name": "West Locker",
         "region": "Side Stairs",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1253,7 +1190,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_sm70_100_HandgunB"
     },
     {
-        "name": "Shelves 1",
+        "name": "North Shelves",
         "region": "East Storage Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1271,7 +1208,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/3FDepot"
     },
     {
-        "name": "Shelves 2",
+        "name": "Southeast Shelves",
         "region": "East Storage Room",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -1539,7 +1476,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Claire_common/Mugnum_Claire"
     },
     {
-        "name": "Table Location 1",
+        "name": "On Table 1",
         "region": "Water Injection Chamber",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1548,7 +1485,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder_BIG"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1665,7 +1602,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location 1",
+        "name": "Downstairs Location",
         "region": "Treatment Pool Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1773,7 +1710,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/SubMachineGun"
     },
     {
-        "name": "Shelves 1",
+        "name": "Shelves",
         "region": "Supplies Storage Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -1933,7 +1870,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "On Bench",
         "region": "Kitchen",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1943,7 +1880,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Near Sinks",
         "region": "Kitchen",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2076,7 +2013,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "Desk",
         "region": "Drug Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2086,7 +2023,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Downed Scientist",
         "region": "Drug Testing Lab",
         "original_item": "Hand Grenade",
         "condition": {},    

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -300,13 +300,13 @@
     },
     { 
         "from": "Parking Garage",
-        "to": "Elevator Controls Room",
+        "to": "Elevator Control Room",
         "condition": {
             "items": ["Diamond Key"]
         }
     },
     { 
-        "from": "Elevator Controls Room",
+        "from": "Elevator Control Room",
         "to": "Chief's Office",
         "condition": {}
     },

--- a/residentevil2remake/data/claire/b/regions.json
+++ b/residentevil2remake/data/claire/b/regions.json
@@ -217,7 +217,7 @@
         "zone_id": 2
     },
     {
-        "name": "Elevator Controls Room",
+        "name": "Elevator Control Room",
         "zone_id": 2
     },
 	

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -411,7 +411,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 1",
+        "name": "Northeastern Desk",
         "region": "STARS Office",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -420,7 +420,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 2",
+        "name": "Box Between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -429,7 +429,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 3",
+        "name": "First Aid On Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -438,7 +438,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 4",
+        "name": "Southeastern Desk",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -456,7 +456,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Location 1",
+        "name": "Towel Rack",
         "region": "Linen Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -465,7 +465,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/LinenRoom"
     },
     {
-        "name": "Location 2",
+        "name": "Washing Machine",
         "region": "Linen Room",
         "original_item": "Spare Key",
         "condition": {},    
@@ -795,7 +795,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/UnderGoddes"
     },
     {
-        "name": "Location 1",
+        "name": "Underneath Staircase",
         "region": "Underground Stairs",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -804,7 +804,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 2",
+        "name": "Cabinet",
         "region": "Underground Stairs",
         "original_item": "Long Barrel - Lightning Hawk",
         "condition": {
@@ -815,7 +815,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_leon"
     },
     {
-        "name": "Location 1",
+        "name": "Northwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -824,7 +824,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 2",
+        "name": "Northwest 2",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -833,7 +833,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 3",
+        "name": "Northwest 3",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -842,7 +842,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 4",
+        "name": "Southwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -851,7 +851,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 5",
+        "name": "Southwest 2",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -860,7 +860,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Location 6",
+        "name": "Southeast 1",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -869,7 +869,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 7",
+        "name": "Southeast 2",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -878,7 +878,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Upstairs Room Location 1",
+        "name": "Staff Room Floor",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -887,7 +887,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Upstairs Room Locker",
+        "name": "Staff Room Locker",
         "region": "Machinery Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -943,7 +943,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Location 2",
+        "name": "Cart Inside Range",
         "region": "Firing Range",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -983,7 +983,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Location 2",
+        "name": "Baskets Near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1073,7 +1073,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker 1",
+        "name": "Left Locker",
         "region": "Break Room",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1082,7 +1082,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/NightDutyRoom/Locker_sm70_207_LeonYakueki"
     },
     {
-        "name": "Locker 2",
+        "name": "Right Locker",
         "region": "Break Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1136,7 +1136,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/InterrogationRoom"
     },
     {
-        "name": "Location 1",
+        "name": "Table",
         "region": "Interrogation Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1154,7 +1154,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor"
     },
     {
-        "name": "3F Locker 1",
+        "name": "South Locker",
         "region": "Side Stairs",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1163,7 +1163,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_WP6300_FlashBan"
     },
     {
-        "name": "3F Locker 2",
+        "name": "West Locker",
         "region": "Side Stairs",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1172,7 +1172,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_sm70_100_HandgunB"
     },
     {
-        "name": "Shelves 1",
+        "name": "North Shelves",
         "region": "East Storage Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1190,7 +1190,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/3FDepot"
     },
     {
-        "name": "Shelves 2",
+        "name": "Southeast Shelves",
         "region": "East Storage Room",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1332,7 +1332,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/Environments/st4_602_0/gimmick/CutScene"
     },
     {
-        "name": "Last Cell 1",
+        "name": "Ben's Corpse",
         "region": "Jail",
         "original_item": "Parking Garage Key Card",
         "condition": {
@@ -1472,7 +1472,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Leon_common/Mugnum_Leon"
     },
     {
-        "name": "Table Location 1",
+        "name": "On Table 1",
         "region": "Water Injection Chamber",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1481,7 +1481,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder_BIG"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1598,7 +1598,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location 1",
+        "name": "Downstairs Location",
         "region": "Treatment Pool Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1697,7 +1697,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common/Magnum"
     },
     {
-        "name": "Shelves 1",
+        "name": "Shelves",
         "region": "Supplies Storage Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -1857,7 +1857,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "On Bench",
         "region": "Kitchen",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1867,7 +1867,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Near Sinks",
         "region": "Kitchen",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1990,7 +1990,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "Desk",
         "region": "Drug Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2000,7 +2000,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Downed Scientist",
         "region": "Drug Testing Lab",
         "original_item": "Hand Grenade",
         "condition": {},    

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -476,7 +476,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 1",
+        "name": "Northeastern Desk",
         "region": "STARS Office",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -485,7 +485,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 2",
+        "name": "Box Between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -494,7 +494,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 3",
+        "name": "First Aid On Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -503,7 +503,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Desks 4",
+        "name": "Southeastern Desk",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -530,7 +530,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Location 1",
+        "name": "Towel Rack",
         "region": "Linen Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -539,7 +539,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/LinenRoom"
     },
     {
-        "name": "Location 2",
+        "name": "Washing Machine",
         "region": "Linen Room",
         "original_item": "Spare Key",
         "condition": {},    
@@ -839,7 +839,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/UnderGoddes"
     },
     {
-        "name": "Location 1",
+        "name": "Underneath Staircase",
         "region": "Underground Stairs",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -848,7 +848,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 2",
+        "name": "Cabinet",
         "region": "Underground Stairs",
         "original_item": "Long Barrel - Lightning Hawk",
         "condition": {
@@ -859,7 +859,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_leon"
     },
     {
-        "name": "Location 1",
+        "name": "Northwest 1",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -868,7 +868,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 2",
+        "name": "Northwest 2",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -877,7 +877,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Location 3",
+        "name": "Northwest 3",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -886,7 +886,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 4",
+        "name": "Southwest 1",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -895,7 +895,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Location 5",
+        "name": "Southwest 2",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -904,7 +904,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Location 6",
+        "name": "Southeast 1",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -913,7 +913,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Location 7",
+        "name": "Southeast 2",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -922,7 +922,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Upstairs Room Location 1",
+        "name": "Staff Room Floor",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -931,7 +931,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Upstairs Room Locker",
+        "name": "Staff Room Locker",
         "region": "Machinery Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -987,7 +987,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Location 2",
+        "name": "Cart Inside Range",
         "region": "Firing Range",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1027,7 +1027,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Location 2",
+        "name": "Baskets Near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1117,7 +1117,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker 1",
+        "name": "Left Locker",
         "region": "Break Room",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1126,7 +1126,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/NightDutyRoom/Locker_sm70_207_LeonYakueki"
     },
     {
-        "name": "Locker 2",
+        "name": "Right Locker",
         "region": "Break Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1180,7 +1180,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/1F/1FE/InterrogationRoom"
     },
     {
-        "name": "Location 1",
+        "name": "Table",
         "region": "Interrogation Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1198,7 +1198,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor"
     },
     {
-        "name": "3F Locker 1",
+        "name": "South Locker",
         "region": "Side Stairs",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1207,7 +1207,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_WP6300_FlashBan"
     },
     {
-        "name": "3F Locker 2",
+        "name": "West Locker",
         "region": "Side Stairs",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1216,7 +1216,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/Corridor/Locker_sm70_100_HandgunB"
     },
     {
-        "name": "Shelves 1",
+        "name": "North Shelves",
         "region": "East Storage Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1234,7 +1234,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FE/3FDepot"
     },
     {
-        "name": "Shelves 2",
+        "name": "Southeast Shelves",
         "region": "East Storage Room",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1376,7 +1376,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/Environments/st4_602_0/gimmick/CutScene"
     },
     {
-        "name": "Last Cell 1",
+        "name": "Ben's Corpse",
         "region": "Jail",
         "original_item": "Parking Garage Key Card",
         "condition": {
@@ -1516,7 +1516,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Leon_common/Mugnum_Leon"
     },
     {
-        "name": "Table Location 1",
+        "name": "On Table 1",
         "region": "Water Injection Chamber",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1525,7 +1525,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder_BIG"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1642,7 +1642,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location 1",
+        "name": "Downstairs Location",
         "region": "Treatment Pool Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1741,7 +1741,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common/Magnum"
     },
     {
-        "name": "Shelves 1",
+        "name": "Shelves",
         "region": "Supplies Storage Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -1901,7 +1901,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "On Bench",
         "region": "Kitchen",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1911,7 +1911,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Near Sinks",
         "region": "Kitchen",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2044,7 +2044,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 1",
+        "name": "Desk",
         "region": "Drug Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2054,7 +2054,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Location 2",
+        "name": "Downed Scientist",
         "region": "Drug Testing Lab",
         "original_item": "Hand Grenade",
         "condition": {},    


### PR DESCRIPTION
Mostly just name changes to make it more discernable for people when they play with or without poptracker 
i.e. Desk 1 <-> Northeastern Desk etc

Also fixes my dumbass mistakes here and there..
- Removes Leon locations in Claire B
- Changes region in locations,json for three items (now renamed to Elevator Control Room) which was leading to the 3 items in that room being accessible without Diamond Key. 

