### PR TITLE
Fix Claire's Sewers regions

### DIFF
--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -349,9 +349,29 @@
     },
     { 
         "from": "Lower Waterway",
+        "to": "Workroom",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    },
+    { 
+        "from": "Workroom",
         "to": "Upper Waterway",
+        "condition": {}
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Lower Waterway",
         "condition": {
             "items": ["Rook Plug"]
+        },
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Water Injection Chamber",
+        "condition": {
+            "items": ["Sewers Key"]
         }
     },
     { 
@@ -366,26 +386,6 @@
         "to": "Underground Stairs",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
-    },
-    { 
-        "from": "Workroom",
-        "to": "Upper Waterway",
-        "condition": {},
-        "limitation": "ONE_SIDED_DOOR"
-    },
-    { 
-        "from": "Upper Waterway",
-        "to": "Water Injection Chamber",
-        "condition": {
-            "items": ["Sewers Key"]
-        }
-    },
-    { 
-        "from": "Lower Waterway",
-        "to": "Workroom",
-        "condition": {
-            "items": ["T-Bar Handle"]
-        }
     },
     { 
         "from": "Lower Waterway",

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -377,9 +377,29 @@
     },
     { 
         "from": "Lower Waterway",
+        "to": "Workroom",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    },
+    { 
+        "from": "Workroom",
         "to": "Upper Waterway",
+        "condition": {}
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Lower Waterway",
         "condition": {
             "items": ["Rook Plug"]
+        },
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Water Injection Chamber",
+        "condition": {
+            "items": ["Sewers Key"]
         }
     },
     { 
@@ -394,26 +414,6 @@
         "to": "Underground Stairs",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
-    },
-    { 
-        "from": "Workroom",
-        "to": "Upper Waterway",
-        "condition": {},
-        "limitation": "ONE_SIDED_DOOR"
-    },
-    { 
-        "from": "Upper Waterway",
-        "to": "Water Injection Chamber",
-        "condition": {
-            "items": ["Sewers Key"]
-        }
-    },
-    { 
-        "from": "Lower Waterway",
-        "to": "Workroom",
-        "condition": {
-            "items": ["T-Bar Handle"]
-        }
     },
     { 
         "from": "Lower Waterway",


### PR DESCRIPTION
Claire starts at a different part of Sewers than Leon does, but her region connections were the same as Leon's. This was putting Upper Waterways into logic before she could logically get there with T-Bar.

**Essentially, this PR makes this key change:**
Claire's connection between Lower Waterway and Upper Waterway becomes a one-sided door to force routing through Workroom (and, subsequently, force getting T-Bar) to get to Upper Waterway and all the connected rooms.

This should fix the logic issues arising from randomized T-Bar.