### PR TITLE
"Troll" setting in Weapon Rando was removing all weapons

### DIFF
--- a/residentevil2remake/WeaponRandomizer.py
+++ b/residentevil2remake/WeaponRandomizer.py
@@ -144,14 +144,16 @@ class WeaponRandomizer():
             only_weapons.append(random_weapon)
             weapons = [w for w in weapons if w['name'] != random_weapon]
 
+        only_weapons_names = [w['name'] for w in only_weapons]
+
         for loc in self._get_weapon_locations():
-            if loc.get('force_item', None) is not None and loc.get('force_item') not in only_weapons:
+            if loc.get('force_item', None) is not None and loc.get('force_item') not in only_weapons_names:
                 loc['force_item'] = 'Wooden Boards'
                 loc_key = self._get_location_key(loc['region'], loc['name'])
                 self.world.source_locations[self.world.player][loc_key] = loc
                 continue
 
-            if loc.get('original_item', None) is not None and loc.get('original_item') not in only_weapons:
+            if loc.get('original_item', None) is not None and loc.get('original_item') not in only_weapons_names:
                 loc['original_item'] = 'Wooden Boards'
                 loc_key = self._get_location_key(loc['region'], loc['name'])
                 self.world.source_locations[self.world.player][loc_key] = loc


### PR DESCRIPTION
Not surprised this one took a while to notice, since probably almost no one plays Troll, lol

The name matching that Troll was doing to limit weapons to only the ones it chose was faulty, so it wasn't matching anything. So it was removing all of the weapons from the seed. :sweat_smile: 