### PR TITLE
Adding "Troll Starting" option to Weapon Rando

### DIFF
--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -141,8 +141,10 @@ class CrossScenarioWeapons(Choice):
     All Ammo: Same as All (adds every weapon from all 4 scenarios), and randomizes how much ammo is placed for each in the world.
     Troll: Same as AllAmmo (every weapon + random ammo), except the randomizer removes all but a few weapons. 
             Ammo and upgrades for the removed weapons are still included to troll you.
-            
-    NOTE: The options for "Full Ammo", "All Ammo", and "Troll" are not guaranteed to be reasonably beatable. Especially Troll. >:)"""
+    Troll Starting: Same as Troll, except the randomizer removes all weapons except for your starting weapon.
+            Ammo and upgrades for the removed weapons are still included as in Troll.
+
+    NOTE: The options for "Full Ammo", "All Ammo", and "Troll" / "Troll Starting" are not guaranteed to be reasonably beatable. Especially the Troll ones. >:)"""
     display_name = "Cross-Scenario Weapons"
     option_none = 0
     option_starting = 1
@@ -152,6 +154,7 @@ class CrossScenarioWeapons(Choice):
     option_full_ammo = 5
     option_all_ammo = 6   
     option_troll = 7
+    option_troll_starting = 8
     default = 0
 
 class AmmoPackModifier(Choice):

--- a/residentevil2remake/WeaponRandomizer.py
+++ b/residentevil2remake/WeaponRandomizer.py
@@ -133,13 +133,13 @@ class WeaponRandomizer():
     ###
     # CrossScenarioWeapons == "Troll"
     ###
-    def troll(self):
+    def troll(self, weapon_count=2):
         # self.all_ammo() is called during processing of options, and self.troll() is specifically called after upgrades, gunpowder, etc.
 
         weapons = [w for w in self._get_weapons_from_locations() if w['name'] != self.world.starting_weapon[self.world.player]]
         only_weapons = [self.world.item_name_to_item.get(self.world.starting_weapon[self.world.player])]
 
-        for _ in range(2):
+        for _ in range(weapon_count):
             random_weapon = self.random.choice(weapons)
             only_weapons.append(random_weapon)
             weapons = [w for w in weapons if w['name'] != random_weapon]
@@ -163,6 +163,12 @@ class WeaponRandomizer():
                     if w['name'] != self.world.starting_weapon[self.world.player]
             ]
         }
+
+    ###
+    # CrossScenarioWeapons == "TrollStarting"
+    ###
+    def troll_starting(self):
+        return self.troll(0) # remove all weapons except the starting weapon
 
     ###
     # Function to be called after ANY weapon rando, so that the upgrades for the included weapons are also included

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -98,7 +98,7 @@ class ResidentEvil2Remake(World):
             weapon_randomizer.full_ammo()
         # all ammo and troll are identical, except there's a step after upgrades are placed for all weapons to remove all but a few weapons
         # so just do all_ammo here, then call the actual troll option after upgrades + gunpowder + whatever else
-        elif weapon_rando == "all ammo" or weapon_rando == "troll": 
+        elif weapon_rando == "all ammo" or weapon_rando == "troll" or weapon_rando == "troll starting": 
             weapon_randomizer.all_ammo()
         else:
             raise "Invalid weapon randomizer value!"
@@ -108,6 +108,8 @@ class ResidentEvil2Remake(World):
 
         if weapon_rando == "troll":
             weapon_randomizer.troll()
+        if weapon_rando == "troll starting":
+            weapon_randomizer.troll_starting()
 
     def create_regions(self): # and create locations
         scenario_locations = { l['id']: l for _, l in self.source_locations[self.player].items() }
@@ -466,6 +468,10 @@ class ResidentEvil2Remake(World):
                     from_weapon = '(Added)'
 
                 if isinstance(to_weapon, list):
+                    if not to_weapon:
+                        spoiler_handle.write(f"\n{from_weapon.ljust(30, ' ')} -> :(")
+                        continue
+
                     spoiler_handle.write(f"\n{from_weapon.ljust(30, ' ')} -> {to_weapon[0]}")
 
                     if len(to_weapon) > 1:


### PR DESCRIPTION
This option is effectively the Troll option, but it leaves you no additional weapons except for the starting one. Everything else about it is the same as Troll.