### PR TITLE
"Oops All" refactor

### DIFF
--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -185,36 +185,15 @@ class AmmoPackModifier(Choice):
     option_random_by_type = 7
     option_random_always = 8
 
-class OopsAllRockets(Choice):
-    """Enabling this swaps all weapons, weapon ammo, and subweapons to Rocket Launchers. 
+class OopsAll(Choice):
+    """Enabling this swaps all weapons, weapon ammo, and subweapons to the selected weapon. 
     (Except progression weapons, of course.)"""
-    display_name = "Oops! All Rockets"
-    option_false = 0
-    option_true = 1
-    default = 0
-
-class OopsAllMiniguns(Choice):
-    """Enabling this swaps all weapons, weapon ammo, and subweapons to Miniguns. 
-    (Except progression weapons, of course.)"""
-    display_name = "Oops! All Miniguns"
-    option_false = 0
-    option_true = 1
-    default = 0
-
-class OopsAllGrenades(Choice):
-    """Enabling this swaps all weapons, weapon ammo, and subweapons to Grenades. 
-    (Except progression weapons, of course.)"""
-    display_name = "Oops! All Grenades"
-    option_false = 0
-    option_true = 1
-    default = 0
-
-class OopsAllKnives(Choice):
-    """Enabling this swaps all weapons, weapon ammo, and subweapons to Knives. 
-    (Except progression weapons, of course.)"""
-    display_name = "Oops! All Knives"
-    option_false = 0
-    option_true = 1
+    display_name = "Oops! All ____"
+    option_none = 0
+    option_rockets = 1
+    option_miniguns = 2
+    option_grenades = 3
+    option_knives = 4
     default = 0
 
 class NoFirstAidSpray(Choice):
@@ -322,10 +301,7 @@ class RE2ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     allow_progression_in_labs: AllowProgressionInLabs
     cross_scenario_weapons: CrossScenarioWeapons
     ammo_pack_modifier: AmmoPackModifier
-    oops_all_rockets: OopsAllRockets
-    oops_all_miniguns: OopsAllMiniguns
-    oops_all_grenades: OopsAllGrenades
-    oops_all_knives: OopsAllKnives
+    oops_all: OopsAll
     no_first_aid_spray: NoFirstAidSpray
     no_green_herb: NoGreenHerb
     no_red_herb: NoRedHerb

--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -193,6 +193,14 @@ class OopsAllRockets(Choice):
     option_true = 1
     default = 0
 
+class OopsAllMiniguns(Choice):
+    """Enabling this swaps all weapons, weapon ammo, and subweapons to Miniguns. 
+    (Except progression weapons, of course.)"""
+    display_name = "Oops! All Miniguns"
+    option_false = 0
+    option_true = 1
+    default = 0
+
 class OopsAllGrenades(Choice):
     """Enabling this swaps all weapons, weapon ammo, and subweapons to Grenades. 
     (Except progression weapons, of course.)"""
@@ -315,6 +323,7 @@ class RE2ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     cross_scenario_weapons: CrossScenarioWeapons
     ammo_pack_modifier: AmmoPackModifier
     oops_all_rockets: OopsAllRockets
+    oops_all_miniguns: OopsAllMiniguns
     oops_all_grenades: OopsAllGrenades
     oops_all_knives: OopsAllKnives
     no_first_aid_spray: NoFirstAidSpray

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -72,9 +72,7 @@ class ResidentEvil2Remake(World):
 
         # if any of the "Oops! All X" weapon options are present, don't bother with weapon randomization since they'll all get overwritten
         #    and since starting with pistol is important to prevent softlock at Gator with all knives
-        if self._format_option_text(self.options.oops_all_rockets) == 'True' or \
-            self._format_option_text(self.options.oops_all_grenades) == 'True' or \
-            self._format_option_text(self.options.oops_all_knives) == 'True':
+        if self.options.oops_all.value != 0:
             return
 
         weapon_rando = self._format_option_text(self.options.cross_scenario_weapons).lower()
@@ -338,84 +336,27 @@ class ResidentEvil2Remake(World):
                     self.multiworld.early_items[self.player][item_name] = item_qty
    
 
-        # check the "Oops! All Rockets" option. From the option description:
-        #     Enabling this swaps all weapons, weapon ammo, and subweapons to Rocket Launchers. 
+        # check the "Oops! All ____" option. From the option description:
+        #     Enabling this swaps all weapons, weapon ammo, and subweapons to the selected weapon. 
         #     (Except progression weapons, of course.)
-        if self._format_option_text(self.options.oops_all_rockets) == 'True':
+        if self.options.oops_all.value != 0:
+            to_item_names = ['None', 'Single Use Rocket', 'Minigun', 'Hand Grenade', 'Combat Knife']
+            
             # leave the Anti-Tank Rocket on Tyrant alone so the player can finish the fight
             items_to_replace = [
                 item for item in self.item_name_to_item.values() 
                 if 'type' in item and item['type'] in ['Weapon', 'Subweapon', 'Ammo'] and item['name'] != 'Anti-tank Rocket'
             ]
-            to_item_name = 'Single Use Rocket'
 
             for from_item in items_to_replace:
-                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_name)
+                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_names[self.options.oops_all.value])
 
             # Add Marvin's Knife back in. He gets cranky if you don't give him his knife.
             for item in pool:
-                if item.name == to_item_name:
+                if item.name == to_item_names[self.options.oops_all.value]:
                     pool.remove(item)
                     pool.append(self.create_item("Combat Knife"))
                     break
-
-        # check the "Oops! All Miniguns" option. From the option description:
-        #     Enabling this swaps all weapons, weapon ammo, and subweapons to Rocket Launchers. 
-        #     (Except progression weapons, of course.)
-        if self._format_option_text(self.options.oops_all_miniguns) == 'True':
-            # leave the Anti-Tank Rocket on Tyrant alone so the player can finish the fight
-            items_to_replace = [
-                item for item in self.item_name_to_item.values() 
-                if 'type' in item and item['type'] in ['Weapon', 'Subweapon', 'Ammo'] and item['name'] != 'Anti-tank Rocket'
-            ]
-            to_item_name = 'Minigun'
-
-            for from_item in items_to_replace:
-                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_name)
-
-            # Add Marvin's Knife back in. He gets cranky if you don't give him his knife.
-            for item in pool:
-                if item.name == to_item_name:
-                    pool.remove(item)
-                    pool.append(self.create_item("Combat Knife"))
-                    break
-
-
-        # check the "Oops! All Grenades" option. From the option description:
-        #     Enabling this swaps all weapons, weapon ammo, and subweapons to Grenades. 
-        #     (Except progression weapons, of course.)
-        if self._format_option_text(self.options.oops_all_grenades) == 'True':
-            # leave the Anti-Tank Rocket on Tyrant alone so the player can finish the fight
-            items_to_replace = [
-                item for item in self.item_name_to_item.values() 
-                if 'type' in item and item['type'] in ['Weapon', 'Subweapon', 'Ammo'] and item['name'] != 'Anti-tank Rocket'
-            ]
-            to_item_name = 'Hand Grenade'
-
-            for from_item in items_to_replace:
-                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_name)
-
-            # Add Marvin's Knife back in. He gets cranky if you don't give him his knife.
-            for item in pool:
-                if item.name == to_item_name:
-                    pool.remove(item)
-                    pool.append(self.create_item("Combat Knife"))
-                    break
-
-        # check the "Oops! All Knives" option. From the option description:
-        #     Enabling this swaps all weapons, weapon ammo, and subweapons to Combat Knives. 
-        #     (Except progression weapons, of course.)
-        if self._format_option_text(self.options.oops_all_knives) == 'True':
-            # leave the Anti-Tank Rocket on Tyrant alone so the player can finish the fight
-            items_to_replace = [
-                item for item in self.item_name_to_item.values() 
-                if 'type' in item and item['type'] in ['Weapon', 'Subweapon', 'Ammo'] and item['name'] != 'Anti-tank Rocket'
-            ]
-            to_item_name = 'Combat Knife'
-
-            for from_item in items_to_replace:
-                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_name)
-
 
         # if the number of unfilled locations exceeds the count of the pool, fill the remainder of the pool with extra maybe helpful items
         missing_item_count = len(self.multiworld.get_unfilled_locations(self.player)) - len(pool)

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -359,6 +359,28 @@ class ResidentEvil2Remake(World):
                     pool.append(self.create_item("Combat Knife"))
                     break
 
+        # check the "Oops! All Miniguns" option. From the option description:
+        #     Enabling this swaps all weapons, weapon ammo, and subweapons to Rocket Launchers. 
+        #     (Except progression weapons, of course.)
+        if self._format_option_text(self.options.oops_all_miniguns) == 'True':
+            # leave the Anti-Tank Rocket on Tyrant alone so the player can finish the fight
+            items_to_replace = [
+                item for item in self.item_name_to_item.values() 
+                if 'type' in item and item['type'] in ['Weapon', 'Subweapon', 'Ammo'] and item['name'] != 'Anti-tank Rocket'
+            ]
+            to_item_name = 'Minigun'
+
+            for from_item in items_to_replace:
+                pool = self._replace_pool_item_with(pool, from_item['name'], to_item_name)
+
+            # Add Marvin's Knife back in. He gets cranky if you don't give him his knife.
+            for item in pool:
+                if item.name == to_item_name:
+                    pool.remove(item)
+                    pool.append(self.create_item("Combat Knife"))
+                    break
+
+
         # check the "Oops! All Grenades" option. From the option description:
         #     Enabling this swaps all weapons, weapon ammo, and subweapons to Grenades. 
         #     (Except progression weapons, of course.)


### PR DESCRIPTION
This does a couple of things:

1. Adds Oops All Miniguns (which by itself is its own branch [here](https://github.com/wcolding/RE2R_AP_World/tree/oops_all_miniguns))
2. Combines all Oops All options into one option

The current version of these options is such that they shouldn't be used together, so this helps prevent players from choosing conflicting settings. It also makes the implementation more streamlined; new options could be added more easily with less copy-paste.

This could use some more actual run testing (as well as a heads up for players that the option changed) before merging. I verified the miniguns work in-game, and otherwise have checks spoiler logs to confirm correct generation.

And if you do like the change, the web YAML options could be a dropdown like Cross Scenario Weapons has.