### PR TITLE
Fix the Early Medallions option

### DIFF
--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -333,7 +333,7 @@ class ResidentEvil2Remake(World):
                 pool.append(self.create_item('Maiden Medallion'))
 
         if self._format_option_text(self.options.early_medallions) == 'True':
-            medallions = {i: len([i2 for i2 in pool if i2.name == i.name]) for i in pool if i.name in ['Lion Medallion', 'Unicorn Medallion', 'Maiden Medallion']}
+            medallions = {i.name: len([i2 for i2 in pool if i2.name == i.name]) for i in pool if i.name in ['Lion Medallion', 'Unicorn Medallion', 'Maiden Medallion']}
 
             for item_name, item_qty in medallions.items():
                 if item_qty > 0:


### PR DESCRIPTION
A typo in the early medallions code caused none of the medallions to be placed early. Fix typo, fixes medallions. :+1: 

(Also, shoutout to Radioactive in the Discord for pointing out what was working in RE3R's early items, which led us to the bug here!)