### PR TITLE
Location+Region and a small amount of Item changes

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -353,7 +353,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/ShowerRoom/Locker_CAP_sm70_108_FireB"
     },
     {
-        "name": "Locker Past Steam",
+        "name": "Locker past Steam",
         "region": "Shower Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -393,7 +393,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "STARS Office",
         "original_item": "Red Herb",
         "condition": {},    
@@ -411,7 +411,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Northeastern Desk",
+        "name": "Desk near Armory",
         "region": "STARS Office",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -420,7 +420,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Box Between Desks",
+        "name": "Box between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -429,7 +429,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "First Aid On Wall",
+        "name": "First Aid on Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -438,7 +438,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Southeastern Desk",
+        "name": "Desk near First Aid Kit",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -501,7 +501,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/Library"
     },
     {
-        "name": "Table By Front Door",
+        "name": "Table by Front Door",
         "region": "Library",
         "original_item": "Red Book",
         "condition": {},    
@@ -529,7 +529,7 @@
         "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
     },
     {
-        "name": "Safe Behind Desk",
+        "name": "Safe behind Desk",
         "region": "Waiting Room",
         "original_item": "High-Capacity Mag - JMB Hp3",
         "condition": {},    
@@ -539,7 +539,7 @@
         "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
     },
     {
-        "name": "Table Near Door",
+        "name": "Table near Door",
         "region": "Art Room",
         "original_item": "Weapons Locker Key Card",
         "condition": {},    
@@ -548,7 +548,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/ArtRoom"
     },
     {
-        "name": "Table By Statue",
+        "name": "Table by Statue",
         "region": "Art Room",
         "original_item": "Statue Left Arm",
         "condition": {},    
@@ -593,7 +593,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Garbage Beside Door",
+        "name": "Garbage beside Door",
         "region": "Fire Escape",
         "original_item": "Bolt Cutters",
         "force_item": "Maiden Medallion",
@@ -603,7 +603,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Green Herb",
         "condition": {},    
@@ -612,7 +612,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Desk By Downed Zombie",
+        "name": "Desk by Downed Zombie",
         "region": "East Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -630,7 +630,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Right Side of Desks",
+        "name": "Middle of Long Desk",
         "region": "East Office",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -639,7 +639,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "End of Desks",
+        "name": "End of Long Desk",
         "region": "East Office",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -730,7 +730,7 @@
         "randomized": 0
     },
     {
-        "name": "Furniture By Door",
+        "name": "Furniture by Door",
         "region": "West Storage Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -739,7 +739,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FW/LickerRoom"
     },
     {
-        "name": "Floor By Furniture",
+        "name": "Floor by Furniture",
         "region": "West Storage Room",
         "original_item": "Wooden Boards",
         "condition": {},    
@@ -815,7 +815,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_claire"
     },
     {
-        "name": "Northwest 1",
+        "name": "On Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -824,7 +824,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Northwest 2",
+        "name": "Near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -833,7 +833,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Northwest 3",
+        "name": "On Containers near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -842,7 +842,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southwest 1",
+        "name": "On Barrel by Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -851,7 +851,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Southwest 2",
+        "name": "On Pallets near Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -860,7 +860,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Southeast 1",
+        "name": "Barrel by Forklift",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -869,7 +869,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southeast 2",
+        "name": "Boxes by Forklift",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -925,7 +925,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Cart Inside Range",
+        "name": "Cart inside Range",
         "region": "Firing Range",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -965,7 +965,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Baskets Near Door",
+        "name": "Baskets near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1083,7 +1083,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/3FE/3FClaireRoom"
     },
     {
-        "name": "Locker",
+        "name": "Locker near Observation Room",
         "region": "Side Stairs",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1119,7 +1119,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/InterrogationRoom"
     },
     {
-        "name": "3F By Stairs",
+        "name": "By 3F Stairs",
         "region": "Side Stairs",
         "original_item": "Wooden Boards",
         "condition": {},    
@@ -1306,7 +1306,7 @@
         "randomized": 0
     },
     {
-        "name": "Just Outside Gate",
+        "name": "Just outside Gate",
         "region": "RPD Streets",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1387,7 +1387,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/Magnum"
     },
     {
-        "name": "At Water Gate",
+        "name": "Trash by Wall of Water",
         "region": "Upper Waterway",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1396,7 +1396,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
-        "name": "In Front of Gate",
+        "name": "Trash beside Gate",
         "region": "Upper Waterway",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -1406,7 +1406,7 @@
     },
     {
         "name": "Downed Zombie",
-        "region": "Upper Waterway",
+        "region": "Waterway Overpass",
         "original_item": "USS Digital Video Cassette",
         "condition": {},    
         "item_object": "sm73_405",
@@ -1432,7 +1432,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder"
     },
     {
-        "name": "Down Elevator",
+        "name": "Ride the Elevator",
         "region": "Workers Break Room",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -1457,15 +1457,6 @@
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ww_2",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/Chemical_claire"
-    },
-    {
-        "name": "Before the Waterslide",
-        "region": "Lower Waterway",
-        "original_item": "Combat Knife",
-        "condition": {},    
-        "item_object": "WP4500",
-        "parent_object": "WP4500_1_ww_01",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Knife"
     },
     {
         "name": "Before Left Path",
@@ -1567,8 +1558,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location",
-        "region": "Treatment Pool Room",
+        "name": "On Boxes near Stairs",
+        "region": "Central Hub",
         "original_item": "Green Herb",
         "condition": {},    
         "item_object": "sm70_001",
@@ -1576,8 +1567,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "End of Left Path",
-        "region": "Lower Waterway",
+        "name": "On Ledge in Water by Trash",
+        "region": "Central Hub",
         "original_item": "Hand Grenade",
         "condition": {},    
         "item_object": "WP6200",
@@ -1621,15 +1612,6 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Rook Panel Outside",
-        "region": "Workroom",
-        "original_item": "Rook Plug",
-        "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
-        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
-    },
-    {
         "name": "Right Table",
         "region": "Workroom",
         "original_item": "Handgun Ammo",
@@ -1639,8 +1621,26 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
+        "name": "Rook Panel",
+        "region": "Waterway Overpass",
+        "original_item": "Rook Plug",
+        "condition": {},    
+        "item_object": "sm73_115",
+        "parent_object": "ItemPositions_1",
+        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
+    },
+    {
+        "name": "Before the Waterslide",
+        "region": "Waterway Overpass",
+        "original_item": "Combat Knife",
+        "condition": {},    
+        "item_object": "WP4500",
+        "parent_object": "WP4500_1_ww_01",
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Knife"
+    },
+    {
         "name": "Keys Panel",
-        "region": "Treatment Pool Room",
+        "region": "Bottom Waterway",
         "original_item": "Sewers Key",
         "condition": {},    
         "item_object": "sm73_429",
@@ -1657,7 +1657,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "Left of 2nd Mutant",
+        "name": "Ledge after 2nd Mutant",
         "region": "Bottom Waterway",
         "original_item": "Submachine Gun Ammo",
         "condition": {},    
@@ -1712,7 +1712,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common"
     },
     {
-        "name": "Stairs After Chess Puzzle",
+        "name": "Stairs after Chess Puzzle",
         "region": "Main Power Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1739,7 +1739,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 1",
+        "name": "Pile of Metal",
         "region": "Proposed Water Purification Room",
         "original_item": "Submachine Gun Ammo",
         "condition": {},    
@@ -1748,7 +1748,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/G2Area_Claire"
     },
     {
-        "name": "Location 2",
+        "name": "Next to Crane Switch",
         "region": "Proposed Water Purification Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1757,7 +1757,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 3",
+        "name": "On Barrel",
         "region": "Proposed Water Purification Room",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1766,7 +1766,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 4",
+        "name": "Stabbed into Sack",
         "region": "Proposed Water Purification Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1908,7 +1908,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Ivy Room Before",
+        "name": "Ivy Area before Control Room",
         "region": "Greenhouse Control Room",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1935,8 +1935,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
-        "forbid_item": ["Sewers Key", "T-Bar Handle"],
-        "randomized": 0
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Drug Testing Lab",
@@ -1979,7 +1978,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Down Ladder Before Lounge",
+        "name": "Down Ladder before Lounge",
         "region": "Lounge - Labs",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -1989,7 +1988,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Bench By Entrance",
+        "name": "Bench by Entrance",
         "region": "Lounge - Labs",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -2009,7 +2008,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Benches Across the Room",
+        "name": "Benches across the Room",
         "region": "Lounge - Labs",
         "original_item": "Green Herb",
         "condition": {},    
@@ -2019,7 +2018,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "Lobby Storage",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -2049,7 +2048,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Across from Robot Arm",
+        "name": "Table across from Robot Arm",
         "region": "Low-Temp Testing Lab",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -2069,7 +2068,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "On Cart By Laptop",
+        "name": "On Cart by Laptop",
         "region": "Server Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2079,7 +2078,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Shelves Left of Typewriter",
+        "name": "Shelves left of Typewriter",
         "region": "Server Room",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -2142,7 +2141,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Cart By Doorway",
+        "name": "Cart by Doorway",
         "region": "P-4 Level Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2172,7 +2171,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 1",
+        "name": "Table right of Elevator 1",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2192,7 +2191,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Left of Entrance",
+        "name": "1st Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -2202,7 +2201,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Left of Entrance",
+        "name": "2nd Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2212,7 +2211,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Right of Entrance",
+        "name": "1st Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2222,7 +2221,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 2",
+        "name": "Table right of Elevator 2",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2252,7 +2251,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Right of Entrance",
+        "name": "2nd Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -2345,7 +2344,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Final Battle By Item Box",
+        "name": "Final Battle by Item Box",
         "region": "Path to G4",
         "original_item": "Red Herb",
         "condition": {},    

--- a/residentevil2remake/data/claire/a/locations_hardcore.json
+++ b/residentevil2remake/data/claire/a/locations_hardcore.json
@@ -18,7 +18,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom/Locker_sm70_100_HandgunB_HardInkribbon"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -54,7 +54,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
     {
-        "name": "Chair Across Room",
+        "name": "Chair across Room",
         "region": "Interrogation Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -72,7 +72,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
 	{
-        "name": "Shelves Before Printer",
+        "name": "Shelves before Printer",
         "region": "Orphanage",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -108,7 +108,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Trash Can By Saving Sherry",
+        "name": "Trash Can before G2 Fight",
         "region": "Main Power Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -147,7 +147,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Typewriter",
+        "name": "Boxes by Typewriter",
         "region": "Path to G4",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -356,30 +356,35 @@
     },
     { 
         "from": "Workroom",
+        "to": "Waterway Overpass",
+        "condition": {}
+    },
+    { 
+        "from": "Waterway Overpass",
         "to": "Upper Waterway",
         "condition": {}
     },
     { 
-        "from": "Upper Waterway",
-        "to": "Lower Waterway",
+        "from": "Waterway Overpass",
+        "to": "Workers Break Room",
         "condition": {
-            "items": ["Rook Plug"]
-        },
-        "limitation": "ONE_SIDED_DOOR"
+            "items": ["Sewers Key"]
+        }
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Water Injection Chamber",
         "condition": {
             "items": ["Sewers Key"]
         }
     },
     { 
-        "from": "Upper Waterway",
-        "to": "Workers Break Room",
+        "from": "Waterway Overpass",
+        "to": "Lower Waterway",
         "condition": {
-            "items": ["Sewers Key"]
-        }
+            "items": ["Rook Plug"]
+        },
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Workers Break Room",
@@ -404,6 +409,17 @@
     },
     { 
         "from": "Treatment Pool Room",
+        "to": "Central Hub",
+        "condition": {}
+    },
+    { 
+        "from": "Central Hub",
+        "to": "Lower Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Central Hub",
         "to": "Bottom Waterway",
         "condition": {
             "items": ["T-Bar Handle"]
@@ -415,6 +431,19 @@
         "condition": {
             "items": ["Queen Plug"]
         }
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Bottom Waterway",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    }, 
+    { 
+        "from": "Bottom Waterway",
+        "to": "Upper Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Monitor Room",

--- a/residentevil2remake/data/claire/a/regions.json
+++ b/residentevil2remake/data/claire/a/regions.json
@@ -226,6 +226,14 @@
         "zone_id": 3
     },
     {
+        "name": "Waterway Overpass",
+        "zone_id": 3
+    },
+    {
+        "name": "Central Hub",
+        "zone_id": 3
+    },
+    {
         "name": "Workroom",
         "zone_id": 3
     },

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -418,7 +418,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/ShowerRoom/Locker_CAP_sm70_108_FireB"
     },
     {
-        "name": "Locker Past Steam",
+        "name": "Locker past Steam",
         "region": "Shower Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -458,7 +458,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Claire_S02_0200/2FW/StarsOffice/WeskerDesk_Claire"
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "STARS Office",
         "original_item": "Red Herb",
         "condition": {},    
@@ -476,7 +476,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Northeastern Desk",
+        "name": "Desk near Armory",
         "region": "STARS Office",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -485,7 +485,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Box Between Desks",
+        "name": "Box between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -494,7 +494,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "First Aid On Wall",
+        "name": "First Aid on Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -503,7 +503,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Southeastern Desk",
+        "name": "Desk near First Aid Kit",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -511,7 +511,7 @@
         "parent_object": "CLAIRE_sm70_208_Claireyakueki",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/2F/2FW/StarsOffice"
     },
-	{
+    {
         "name": "On Cart by Armory",
         "region": "STARS Office",
         "original_item": "Large-Caliber Handgun Ammo",
@@ -575,7 +575,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/Library"
     },
     {
-        "name": "Table By Front Door",
+        "name": "Table by Front Door",
         "region": "Library",
         "original_item": "Red Book",
         "condition": {},    
@@ -602,7 +602,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/WaitingRoom"
     },
     {
-        "name": "Safe Behind Desk",
+        "name": "Safe behind Desk",
         "region": "Waiting Room",
         "original_item": "High-Capacity Mag - JMB Hp3",
         "condition": {},    
@@ -611,7 +611,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0000/Claire_S02_0000/2FE/2FWaitingRoom/IronSafe_2FE"
     },
     {
-        "name": "Table Near Door",
+        "name": "Table near Door",
         "region": "Art Room",
         "original_item": "Weapons Locker Key Card",
         "condition": {},    
@@ -620,7 +620,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/ArtRoom"
     },
     {
-        "name": "Table By Statue",
+        "name": "Table by Statue",
         "region": "Art Room",
         "original_item": "Statue Left Arm",
         "condition": {},    
@@ -665,7 +665,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Green Herb",
         "condition": {},    
@@ -674,7 +674,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Desk By Downed Zombie",
+        "name": "Desk by Downed Zombie",
         "region": "East Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -692,7 +692,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Right Side of Desks",
+        "name": "Middle of Long Desk",
         "region": "East Office",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -783,7 +783,7 @@
         "randomized": 0
     },
     {
-        "name": "Furniture By Door",
+        "name": "Furniture by Door",
         "region": "West Storage Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -792,7 +792,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FW/LickerRoom"
     },
     {
-        "name": "Floor By Furniture",
+        "name": "Floor by Furniture",
         "region": "West Storage Room",
         "original_item": "Wooden Boards",
         "condition": {},    
@@ -859,7 +859,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_claire"
     },
     {
-        "name": "Northwest 1",
+        "name": "On Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -868,7 +868,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Northwest 2",
+        "name": "Near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -877,7 +877,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Northwest 3",
+        "name": "On Containers near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -886,7 +886,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southwest 1",
+        "name": "On Barrel by Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -895,7 +895,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Southwest 2",
+        "name": "On Pallets near Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -904,7 +904,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Southeast 1",
+        "name": "Barrel by Forklift",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -913,7 +913,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southeast 2",
+        "name": "Boxes by Forklift",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -969,7 +969,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Cart Inside Range",
+        "name": "Cart inside Range",
         "region": "Firing Range",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -1009,7 +1009,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Baskets Near Door",
+        "name": "Baskets near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1044,7 +1044,7 @@
         "parent_object": "Key_DiaMark_Leon",
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_702_0/gimmick"
     },
-	{
+    {
         "name": "Locker",
         "region": "Elevator Control Room",
         "original_item": "Shoulder Stock - GM 79",
@@ -1066,7 +1066,7 @@
         "parent_object": "sm70_208",
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Claire_common/WhiteChemical_CLEAR"
     },
-	{
+    {
         "name": "Corner of Room on Ground",
         "region": "Elevator Control Room",
         "original_item": "Blue Herb",
@@ -1154,7 +1154,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker 1",
+        "name": "Left Locker",
         "region": "Break Room",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1163,7 +1163,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Claire_common/1F/1FE/NightDutyRoom/Locker_sm70_208_ClaireYakueki"
     },
     {
-        "name": "Locker 2",
+        "name": "Right Locker",
         "region": "Break Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1190,7 +1190,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker",
+        "name": "Locker near Observation Room",
         "region": "Side Stairs",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -1413,7 +1413,7 @@
         "randomized": 0
     },
     {
-        "name": "Just Outside Gate",
+        "name": "Just outside Gate",
         "region": "RPD Streets",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1494,7 +1494,16 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/Magnum"
     },
     {
-        "name": "In Front of Gate",
+        "name": "Trash by Wall of Water",
+        "region": "Upper Waterway",
+        "original_item": "Large-Caliber Handgun Ammo",
+        "condition": {},    
+        "item_object": "sm70_111",
+        "parent_object": "sm70_111",
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
+    },
+    {
+        "name": "Trash beside Gate",
         "region": "Upper Waterway",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -1504,7 +1513,7 @@
     },
     {
         "name": "Downed Zombie",
-        "region": "Upper Waterway",
+        "region": "Waterway Overpass",
         "original_item": "USS Digital Video Cassette",
         "condition": {},    
         "item_object": "sm73_405",
@@ -1530,7 +1539,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder"
     },
     {
-        "name": "Down Elevator",
+        "name": "Ride the Elevator",
         "region": "Workers Break Room",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -1555,15 +1564,6 @@
         "item_object": "sm70_208",
         "parent_object": "sm70_208_ww_2",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/Chemical_claire"
-    },
-    {
-        "name": "Before the Waterslide",
-        "region": "Lower Waterway",
-        "original_item": "Combat Knife",
-        "condition": {},    
-        "item_object": "WP4500",
-        "parent_object": "WP4500_1_ww_01",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Knife"
     },
     {
         "name": "Before Left Path",
@@ -1665,8 +1665,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location",
-        "region": "Treatment Pool Room",
+        "name": "On Boxes near Stairs",
+        "region": "Central Hub",
         "original_item": "Green Herb",
         "condition": {},    
         "item_object": "sm70_001",
@@ -1674,8 +1674,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "End of Left Path",
-        "region": "Lower Waterway",
+        "name": "On Ledge in Water by Trash",
+        "region": "Central Hub",
         "original_item": "Hand Grenade",
         "condition": {},    
         "item_object": "WP6200",
@@ -1719,15 +1719,6 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Rook Panel Outside",
-        "region": "Workroom",
-        "original_item": "Rook Plug",
-        "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
-        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
-    },
-    {
         "name": "Right Table",
         "region": "Workroom",
         "original_item": "Large-Caliber Handgun Ammo",
@@ -1737,22 +1728,31 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
+        "name": "Rook Panel",
+        "region": "Waterway Overpass",
+        "original_item": "Rook Plug",
+        "condition": {},    
+        "item_object": "sm73_115",
+        "parent_object": "ItemPositions_1",
+        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
+    },
+    {
+        "name": "Before the Waterslide",
+        "region": "Waterway Overpass",
+        "original_item": "Combat Knife",
+        "condition": {},    
+        "item_object": "WP4500",
+        "parent_object": "WP4500_1_ww_01",
+        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Knife"
+    },
+    {
         "name": "Keys Panel",
-        "region": "Treatment Pool Room",
+        "region": "Bottom Waterway",
         "original_item": "Sewers Key",
         "condition": {},    
         "item_object": "sm73_429",
         "parent_object": "Key_Gesui_ura",
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
-    },
-    {
-        "name": "At Water Gate",
-        "region": "Upper Waterway",
-        "original_item": "Large-Caliber Handgun Ammo",
-        "condition": {},    
-        "item_object": "sm70_111",
-        "parent_object": "sm70_111",
-        "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
         "name": "Before Climb",
@@ -1764,7 +1764,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "Left of 2nd Mutant",
+        "name": "Ledge after 2nd Mutant",
         "region": "Bottom Waterway",
         "original_item": "Submachine Gun Ammo",
         "condition": {},    
@@ -1819,7 +1819,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common"
     },
     {
-        "name": "Stairs After Chess Puzzle",
+        "name": "Stairs after Chess Puzzle",
         "region": "Main Power Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1846,7 +1846,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 1",
+        "name": "Pile of Metal",
         "region": "Proposed Water Purification Room",
         "original_item": "Submachine Gun Ammo",
         "condition": {},    
@@ -1855,7 +1855,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Claire_common/G2Area_Claire"
     },
     {
-        "name": "Location 2",
+        "name": "Next to Crane Switch",
         "region": "Proposed Water Purification Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1864,7 +1864,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 3",
+        "name": "On Barrel",
         "region": "Proposed Water Purification Room",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1873,7 +1873,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 4",
+        "name": "Stabbed into Sack",
         "region": "Proposed Water Purification Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1896,7 +1896,7 @@
         "name": "Desk",
         "region": "Security Room",
         "original_item": "GM 79",
-        "condition": {},
+        "condition": {},    
         "item_object": "WP4100",
         "parent_object": "WP4100_Grenade",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/Claire_common/StartArea/Sherry Room",
@@ -1994,7 +1994,7 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
-	{
+    {
         "name": "Next to Soldier",
         "region": "Main Shaft",
         "original_item": "Signal Modulator",
@@ -2025,7 +2025,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Ivy Room Before",
+        "name": "Ivy Area before Control Room",
         "region": "Greenhouse Control Room",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -2052,8 +2052,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
-        "forbid_item": ["Sewers Key", "T-Bar Handle"],
-        "randomized": 0
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Drug Testing Lab",
@@ -2096,7 +2095,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Down Ladder Before Lounge",
+        "name": "Down Ladder before Lounge",
         "region": "Lounge - Labs",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2106,7 +2105,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Bench By Entrance",
+        "name": "Bench by Entrance",
         "region": "Lounge - Labs",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -2116,7 +2115,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Benches Across the Room",
+        "name": "Benches across the Room",
         "region": "Lounge - Labs",
         "original_item": "Green Herb",
         "condition": {},    
@@ -2126,7 +2125,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "Lobby Storage",
         "original_item": "High-Grade Gunpowder - White",
         "condition": {},    
@@ -2146,7 +2145,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Across from Robot Arm",
+        "name": "Table across from Robot Arm",
         "region": "Low-Temp Testing Lab",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -2155,7 +2154,7 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
-	{
+    {
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
         "original_item": "Trophy B",
@@ -2176,7 +2175,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "On Cart By Laptop",
+        "name": "On Cart by Laptop",
         "region": "Server Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2186,7 +2185,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Shelves Left of Typewriter",
+        "name": "Shelves left of Typewriter",
         "region": "Server Room",
         "original_item": "Flame Rounds",
         "condition": {},    
@@ -2202,7 +2201,7 @@
         "force_item": "ID Wristband - Senior Staff",
         "condition": {
             "items": ["Signal Modulator"]
-        },     
+        },    
         "item_object": "sm73_434",
         "parent_object": "sm73_434_WristtagUpdater_Lv2",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/GreenHouse",
@@ -2249,7 +2248,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Cart By Doorway",
+        "name": "Cart by Doorway",
         "region": "P-4 Level Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2279,7 +2278,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 1",
+        "name": "Table right of Elevator 1",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2299,7 +2298,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Left of Entrance",
+        "name": "1st Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -2309,7 +2308,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Left of Entrance",
+        "name": "2nd Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2319,7 +2318,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Right of Entrance",
+        "name": "1st Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2329,7 +2328,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 2",
+        "name": "Table right of Elevator 2",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2359,7 +2358,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Right of Entrance",
+        "name": "2nd Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "High-Powered Rounds",
         "condition": {},    
@@ -2452,7 +2451,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Final Battle By Item Box",
+        "name": "Final Battle by Item Box",
         "region": "Path to G4",
         "original_item": "Red Herb",
         "condition": {},    

--- a/residentevil2remake/data/claire/b/locations_hardcore.json
+++ b/residentevil2remake/data/claire/b/locations_hardcore.json
@@ -27,7 +27,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom/Locker_sm70_100_HandgunB_HardInkribbon"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -81,7 +81,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
 	{
-        "name": "Shelves Before Printer",
+        "name": "Shelves before Printer",
         "region": "Orphanage",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -117,7 +117,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Trash Can By Saving Sherry",
+        "name": "Trash Can before G2 Fight",
         "region": "Main Power Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -156,7 +156,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Typewriter",
+        "name": "Boxes by Typewriter",
         "region": "Path to G4",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -384,30 +384,35 @@
     },
     { 
         "from": "Workroom",
+        "to": "Waterway Overpass",
+        "condition": {}
+    },
+    { 
+        "from": "Waterway Overpass",
         "to": "Upper Waterway",
         "condition": {}
     },
     { 
-        "from": "Upper Waterway",
-        "to": "Lower Waterway",
+        "from": "Waterway Overpass",
+        "to": "Workers Break Room",
         "condition": {
-            "items": ["Rook Plug"]
-        },
-        "limitation": "ONE_SIDED_DOOR"
+            "items": ["Sewers Key"]
+        }
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Water Injection Chamber",
         "condition": {
             "items": ["Sewers Key"]
         }
     },
     { 
-        "from": "Upper Waterway",
-        "to": "Workers Break Room",
+        "from": "Waterway Overpass",
+        "to": "Lower Waterway",
         "condition": {
-            "items": ["Sewers Key"]
-        }
+            "items": ["Rook Plug"]
+        },
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Workers Break Room",
@@ -432,6 +437,17 @@
     },
     { 
         "from": "Treatment Pool Room",
+        "to": "Central Hub",
+        "condition": {}
+    },
+    { 
+        "from": "Central Hub",
+        "to": "Lower Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Central Hub",
         "to": "Bottom Waterway",
         "condition": {
             "items": ["T-Bar Handle"]
@@ -443,6 +459,19 @@
         "condition": {
             "items": ["Queen Plug"]
         }
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Bottom Waterway",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    }, 
+    { 
+        "from": "Bottom Waterway",
+        "to": "Upper Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Monitor Room",

--- a/residentevil2remake/data/claire/b/regions.json
+++ b/residentevil2remake/data/claire/b/regions.json
@@ -242,6 +242,14 @@
         "zone_id": 3
     },
     {
+        "name": "Waterway Overpass",
+        "zone_id": 3
+    },
+    {
+        "name": "Central Hub",
+        "zone_id": 3
+    },
+    {
         "name": "Workroom",
         "zone_id": 3
     },

--- a/residentevil2remake/data/claire/items.json
+++ b/residentevil2remake/data/claire/items.json
@@ -340,21 +340,21 @@
         "name": "Film - Commemorative",
         "decimal": "74",
         "count": 1,
-        "progression": 1
+        "progression": 0
     },
     {
         "type": "Gating",
         "name": "Film - Lion Statue",
         "decimal": "76",
         "count": 1,
-        "progression": 1
+        "progression": 0
     },
     {
         "type": "Gating",
         "name": "Film - 3F Locker",
         "decimal": "75",
         "count": 1,
-        "progression": 1
+        "progression": 0
     },
     {
         "type": "Gating",
@@ -368,7 +368,7 @@
         "name": "Film - Rising Rookie",
         "decimal": "73",
         "count": 1,
-        "progression": 1
+        "progression": 0
     },
 
     {
@@ -448,7 +448,7 @@
         "name": "SLS 60",
         "groups": ["pistol", "light_gun"],
         "decimal": "9",
-        "count": 10,
+        "count": 5,
         "progression": 0,
         "ammo": "Handgun Ammo"
     },
@@ -457,7 +457,7 @@
         "name": "Quickdraw Army",
         "groups": ["pistol", "light_gun"],
         "decimal": "4",
-        "count": 10,
+        "count": 6,
         "progression": 0,
         "ammo": "Large-Caliber Handgun Ammo"
     },
@@ -466,7 +466,7 @@
         "name": "GM 79",
         "groups": ["grenade", "grenade launcher", "medium_gun"],
         "decimal": "42",
-        "count": 0,
+        "count": 1,
         "progression": 0,
         "ammo": "Flame Rounds"
     },
@@ -475,7 +475,7 @@
         "name": "JMB Hp3",
         "groups": ["pistol", "medium_gun"],
         "decimal": "3",
-        "count": 10,
+        "count": 13,
         "progression": 0,
         "ammo": "Handgun Ammo"
     },

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -353,7 +353,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/ShowerRoom/Locker_CAP_sm70_101_ShotgunB"
     },
     {
-        "name": "Locker Past Steam",
+        "name": "Locker past Steam",
         "region": "Shower Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -393,7 +393,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "STARS Office",
         "original_item": "Red Herb",
         "condition": {},    
@@ -411,7 +411,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Northeastern Desk",
+        "name": "Desk near Armory",
         "region": "STARS Office",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -420,7 +420,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Box Between Desks",
+        "name": "Box between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -429,7 +429,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "First Aid On Wall",
+        "name": "First Aid on Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -438,7 +438,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Southeastern Desk",
+        "name": "Desk near First Aid Kit",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -501,7 +501,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/Library"
     },
     {
-        "name": "Table By Front Door",
+        "name": "Table by Front Door",
         "region": "Library",
         "original_item": "Red Book",
         "condition": {},    
@@ -529,7 +529,7 @@
         "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
     },
     {
-        "name": "Safe Behind Desk",
+        "name": "Safe behind Desk",
         "region": "Waiting Room",
         "original_item": "Muzzle Brake - Matilda",
         "condition": {},    
@@ -539,7 +539,7 @@
         "forbid_item": ["Fuse - Main Hall", "Fuse - Break Room Hallway", "Bolt Cutters"]
     },
     {
-        "name": "Table Near Door",
+        "name": "Table near Door",
         "region": "Art Room",
         "original_item": "Weapons Locker Key Card",
         "condition": {},    
@@ -548,7 +548,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/ArtRoom"
     },
     {
-        "name": "Table By Statue",
+        "name": "Table by Statue",
         "region": "Art Room",
         "original_item": "Statue Left Arm",
         "condition": {},    
@@ -593,7 +593,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Garbage Beside Door",
+        "name": "Garbage beside Door",
         "region": "Fire Escape",
         "original_item": "Bolt Cutters",
         "force_item": "Maiden Medallion",
@@ -603,7 +603,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Green Herb",
         "condition": {},    
@@ -612,7 +612,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Desk By Downed Zombie",
+        "name": "Desk by Downed Zombie",
         "region": "East Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -630,7 +630,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Right Side of Desks",
+        "name": "Middle of Long Desk",
         "region": "East Office",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -730,7 +730,7 @@
         "randomized": 0
     },
     {
-        "name": "Furniture By Door",
+        "name": "Furniture by Door",
         "region": "West Storage Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -739,7 +739,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FW/LickerRoom"
     },
     {
-        "name": "Floor By Furniture",
+        "name": "Floor by Furniture",
         "region": "West Storage Room",
         "original_item": "Wooden Boards",
         "condition": {},    
@@ -815,7 +815,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_leon"
     },
     {
-        "name": "Northwest 1",
+        "name": "On Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -824,7 +824,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Northwest 2",
+        "name": "Near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -833,7 +833,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Northwest 3",
+        "name": "On Containers near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -842,7 +842,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southwest 1",
+        "name": "On Barrel by Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -851,7 +851,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Southwest 2",
+        "name": "On Pallets near Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -860,7 +860,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Southeast 1",
+        "name": "Barrel by Forklift",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -869,7 +869,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southeast 2",
+        "name": "Boxes by Forklift",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -943,7 +943,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Cart Inside Range",
+        "name": "Cart inside Range",
         "region": "Firing Range",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -983,7 +983,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Baskets Near Door",
+        "name": "Baskets near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1109,7 +1109,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker",
+        "name": "Locker near Observation Room",
         "region": "Side Stairs",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1355,7 +1355,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/EmergencySpray"
     },
     {
-        "name": "Just Outside Gate",
+        "name": "Just outside Gate",
         "region": "RPD Streets",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1400,7 +1400,7 @@
         "folder_path": "RopewayContents/World/Location_CrocodiliaArea/LocationLevel_CrocodiliaArea/Item/common/Leon_common"
     },
     {
-        "name": "Barrels Before Alligator Cutscene",
+        "name": "Barrels before Alligator Cutscene",
         "region": "Sewers Entrance",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1418,7 +1418,7 @@
         "folder_path": "RopewayContents/World/Location_CrocodiliaArea/LocationLevel_CrocodiliaArea/Item/common/Leon_common"
     },
     {
-        "name": "At Water Gate",
+        "name": "Trash by Wall of Water",
         "region": "Upper Waterway",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1427,7 +1427,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
-        "name": "In Front of Gate",
+        "name": "Trash beside Gate",
         "region": "Upper Waterway",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1437,7 +1437,7 @@
     },
     {
         "name": "Downed Zombie",
-        "region": "Upper Waterway",
+        "region": "Waterway Overpass",
         "original_item": "USS Digital Video Cassette",
         "condition": {},    
         "item_object": "sm73_405",
@@ -1463,7 +1463,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder"
     },
     {
-        "name": "Down Elevator",
+        "name": "Ride the Elevator",
         "region": "Workers Break Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1491,7 +1491,7 @@
     },
     {
         "name": "Before the Waterslide",
-        "region": "Lower Waterway",
+        "region": "Waterway Overpass",
         "original_item": "Combat Knife",
         "condition": {},    
         "item_object": "WP4500",
@@ -1598,8 +1598,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location",
-        "region": "Treatment Pool Room",
+        "name": "On Boxes near Stairs",
+        "region": "Central Hub",
         "original_item": "Green Herb",
         "condition": {},    
         "item_object": "sm70_001",
@@ -1607,8 +1607,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "End of Left Path",
-        "region": "Lower Waterway",
+        "name": "On Ledge in Water by Trash",
+        "region": "Central Hub",
         "original_item": "Hand Grenade",
         "condition": {},    
         "item_object": "WP6200",
@@ -1652,15 +1652,6 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Rook Panel Outside",
-        "region": "Workroom",
-        "original_item": "Rook Plug",
-        "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
-        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
-    },
-    {
         "name": "Right Table",
         "region": "Workroom",
         "original_item": "Handgun Ammo",
@@ -1670,8 +1661,17 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
+        "name": "Rook Panel",
+        "region": "Waterway Overpass",
+        "original_item": "Rook Plug",
+        "condition": {},    
+        "item_object": "sm73_115",
+        "parent_object": "ItemPositions_1",
+        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
+    },
+    {
         "name": "Keys Panel",
-        "region": "Treatment Pool Room",
+        "region": "Bottom Waterway",
         "original_item": "Sewers Key",
         "condition": {},    
         "item_object": "sm73_429",
@@ -1688,7 +1688,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "Left of 2nd Mutant",
+        "name": "Ledge after 2nd Mutant",
         "region": "Bottom Waterway",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1743,7 +1743,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common"
     },
     {
-        "name": "Stairs After Chess Puzzle",
+        "name": "Stairs after Chess Puzzle",
         "region": "Main Power Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1770,7 +1770,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 1",
+        "name": "Pile of Metal",
         "region": "Proposed Water Purification Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1779,7 +1779,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common/G2Area_Leon"
     },
     {
-        "name": "Location 2",
+        "name": "Next to Crane Switch",
         "region": "Proposed Water Purification Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -1788,7 +1788,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 3",
+        "name": "On Barrel",
         "region": "Proposed Water Purification Room",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1797,7 +1797,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 4",
+        "name": "Stabbed into Sack",
         "region": "Proposed Water Purification Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1939,7 +1939,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Ivy Room Before",
+        "name": "Ivy Area before Control Room",
         "region": "Greenhouse Control Room",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1966,8 +1966,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
-        "forbid_item": ["Sewers Key", "T-Bar Handle"],
-        "randomized": 0
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Drug Testing Lab",
@@ -2010,7 +2009,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Down Ladder Before Lounge",
+        "name": "Down Ladder before Lounge",
         "region": "Lounge - Labs",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2020,7 +2019,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Bench By Entrance",
+        "name": "Bench by Entrance",
         "region": "Lounge - Labs",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -2040,7 +2039,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Benches Across the Room",
+        "name": "Benches across the Room",
         "region": "Lounge - Labs",
         "original_item": "Green Herb",
         "condition": {},    
@@ -2050,7 +2049,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "Lobby Storage",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -2080,7 +2079,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Across from Robot Arm",
+        "name": "Table across from Robot Arm",
         "region": "Low-Temp Testing Lab",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -2100,7 +2099,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "On Cart By Laptop",
+        "name": "On Cart by Laptop",
         "region": "Server Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2110,7 +2109,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Shelves Left of Typewriter",
+        "name": "Shelves left of Typewriter",
         "region": "Server Room",
         "original_item": "Flamethrower Fuel",
         "condition": {},    
@@ -2173,7 +2172,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Cart By Doorway",
+        "name": "Cart by Doorway",
         "region": "P-4 Level Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2203,7 +2202,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 1",
+        "name": "Table right of Elevator 1",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2223,7 +2222,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Left of Entrance",
+        "name": "1st Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -2233,7 +2232,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Left of Entrance",
+        "name": "2nd Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2243,7 +2242,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Right of Entrance",
+        "name": "1st Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2253,7 +2252,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 2",
+        "name": "Table right of Elevator 2",
         "region": "Bioreactors Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -2283,7 +2282,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Right of Entrance",
+        "name": "2nd Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -2373,7 +2372,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Final Battle By Item Box",
+        "name": "Final Battle by Item Box",
         "region": "Path to Super Tyrant",
         "original_item": "Red Herb",
         "condition": {},    

--- a/residentevil2remake/data/leon/a/locations_hardcore.json
+++ b/residentevil2remake/data/leon/a/locations_hardcore.json
@@ -18,7 +18,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom/Locker_sm70_100_HandgunB_HardInkribbon"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -54,7 +54,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
     {
-        "name": "Chair Across Room",
+        "name": "Chair across Room",
         "region": "Interrogation Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -72,7 +72,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
     {
-        "name": "Barrels Before Alligator Cutscene",
+        "name": "Barrels before Alligator Cutscene",
         "region": "Sewers Entrance",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -99,7 +99,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Trash Can By Saving Ada",
+        "name": "Trash Can by Saving Ada",
         "region": "Main Power Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -138,9 +138,9 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Typewriter",
+        "name": "Boxes by Typewriter",
         "region": "Path to Super Tyrant",
-        "original_item": "Ink Ribbon",
+        "original_item": "",
         "condition": {},    
         "item_object": "sm70_201",
         "parent_object": "sm70_201",

--- a/residentevil2remake/data/leon/a/region_connections.json
+++ b/residentevil2remake/data/leon/a/region_connections.json
@@ -387,6 +387,11 @@
     },
     { 
         "from": "Upper Waterway",
+        "to": "Waterway Overpass",
+        "condition": {}
+    },
+    { 
+        "from": "Waterway Overpass",
         "to": "Workers Break Room",
         "condition": {
             "items": ["Sewers Key"]
@@ -400,19 +405,19 @@
     },
     { 
         "from": "Workroom",
-        "to": "Upper Waterway",
+        "to": "Waterway Overpass",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Water Injection Chamber",
         "condition": {
             "items": ["Sewers Key"]
         }
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Lower Waterway",
         "condition": {}
     },
@@ -440,6 +445,17 @@
     },
     { 
         "from": "Treatment Pool Room",
+        "to": "Central Hub",
+        "condition": {}
+    },
+    { 
+        "from": "Central Hub",
+        "to": "Lower Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Central Hub",
         "to": "Bottom Waterway",
         "condition": {
             "items": ["T-Bar Handle"]
@@ -451,6 +467,19 @@
         "condition": {
             "items": ["Queen Plug"]
         }
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Bottom Waterway",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    }, 
+    { 
+        "from": "Bottom Waterway",
+        "to": "Upper Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Monitor Room",

--- a/residentevil2remake/data/leon/a/regions.json
+++ b/residentevil2remake/data/leon/a/regions.json
@@ -285,6 +285,14 @@
         "name": "Bottom Waterway",
         "zone_id": 3
     },
+    {
+        "name": "Waterway Overpass",
+        "zone_id": 3
+    },
+    {
+        "name": "Central Hub",
+        "zone_id": 3
+    },
     
     {
         "name": "Cable Car Platform",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -418,7 +418,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/ShowerRoom/Locker_CAP_sm70_101_ShotgunB"
     },
     {
-        "name": "Locker Past Steam",
+        "name": "Locker past Steam",
         "region": "Shower Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -458,7 +458,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0200/Leon_S02_0200/2FW/StarsOffice/WeskerDesk_LEON"
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "STARS Office",
         "original_item": "Red Herb",
         "condition": {},    
@@ -476,7 +476,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Northeastern Desk",
+        "name": "Desk near Armory",
         "region": "STARS Office",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -485,7 +485,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Box Between Desks",
+        "name": "Box between Desks",
         "region": "STARS Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -494,7 +494,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "First Aid On Wall",
+        "name": "First Aid on Wall",
         "region": "STARS Office",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -503,7 +503,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/StarsOffice"
     },
     {
-        "name": "Southeastern Desk",
+        "name": "Desk near First Aid Kit",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -511,7 +511,7 @@
         "parent_object": "LEON_sm70_207_Leonyakueki",
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/Leon_common/2F/2FW/StarsOffice"
     },
-	{
+    {
         "name": "On Cart by Armory",
         "region": "STARS Office",
         "original_item": "High-Grade Gunpowder - Yellow",
@@ -575,7 +575,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FW/Library"
     },
     {
-        "name": "Table By Front Door",
+        "name": "Table by Front Door",
         "region": "Library",
         "original_item": "Red Book",
         "condition": {},    
@@ -602,7 +602,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/WaitingRoom"
     },
     {
-        "name": "Safe Behind Desk",
+        "name": "Safe behind Desk",
         "region": "Waiting Room",
         "original_item": "Muzzle Brake - Matilda",
         "condition": {},    
@@ -611,7 +611,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/LocationFsm_RPD/S02_0000/Leon_S02_0000/2FE/2FWaitingRoom/IronSafe_2FE"
     },
     {
-        "name": "Table Near Door",
+        "name": "Table near Door",
         "region": "Art Room",
         "original_item": "Weapons Locker Key Card",
         "condition": {},    
@@ -620,7 +620,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/2F/2FE/ArtRoom"
     },
     {
-        "name": "Table By Statue",
+        "name": "Table by Statue",
         "region": "Art Room",
         "original_item": "Statue Left Arm",
         "condition": {},    
@@ -665,7 +665,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/OutdoorS"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Green Herb",
         "condition": {},    
@@ -674,7 +674,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Desk By Downed Zombie",
+        "name": "Desk by Downed Zombie",
         "region": "East Office",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -692,7 +692,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/OfficeE"
     },
     {
-        "name": "Right Side of Desks",
+        "name": "Middle of Long Desk",
         "region": "East Office",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -783,7 +783,7 @@
         "randomized": 0
     },
     {
-        "name": "Furniture By Door",
+        "name": "Furniture by Door",
         "region": "West Storage Room",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -792,7 +792,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/3FHigher/3FW/LickerRoom"
     },
     {
-        "name": "Floor By Furniture",
+        "name": "Floor by Furniture",
         "region": "West Storage Room",
         "original_item": "Wooden Boards",
         "condition": {},    
@@ -859,7 +859,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/Environments/st4_750_0/gimmick_leon"
     },
     {
-        "name": "Northwest 1",
+        "name": "On Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Handgun Ammo",
         "condition": {},    
@@ -868,7 +868,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Northwest 2",
+        "name": "Near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Hand Grenade",
         "condition": {},    
@@ -877,7 +877,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/Weapon/Granade"
     },
     {
-        "name": "Northwest 3",
+        "name": "On Containers near Tarped Machinery",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -886,7 +886,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southwest 1",
+        "name": "On Barrel by Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -895,7 +895,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/HundGun"
     },
     {
-        "name": "Southwest 2",
+        "name": "On Pallets near Steamy Machinery",
         "region": "Machinery Room",
         "original_item": "Red Herb",
         "condition": {},    
@@ -904,7 +904,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/RedHerb"
     },
     {
-        "name": "Southeast 1",
+        "name": "Barrel by Forklift",
         "region": "Machinery Room",
         "original_item": "Green Herb",
         "condition": {},    
@@ -913,7 +913,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/green_herb"
     },
     {
-        "name": "Southeast 2",
+        "name": "Boxes by Forklift",
         "region": "Machinery Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -987,7 +987,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/KeyItem"
     },
     {
-        "name": "Cart Inside Range",
+        "name": "Cart inside Range",
         "region": "Firing Range",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1027,7 +1027,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/BlueHerb"
     },
     {
-        "name": "Baskets Near Door",
+        "name": "Baskets near Door",
         "region": "Kennel",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1153,7 +1153,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FE/NightDutyRoom"
     },
     {
-        "name": "Locker",
+        "name": "Locker near Observation Room",
         "region": "Side Stairs",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -1399,7 +1399,7 @@
         "folder_path": "RopewayContents/World/Location_RPD_B1/LocationLevel_RPD_B1/Item/common/EmergencySpray"
     },
     {
-        "name": "Just Outside Gate",
+        "name": "Just outside Gate",
         "region": "RPD Streets",
         "original_item": "Green Herb",
         "condition": {},    
@@ -1444,7 +1444,7 @@
         "folder_path": "RopewayContents/World/Location_CrocodiliaArea/LocationLevel_CrocodiliaArea/Item/common/Leon_common"
     },
     {
-        "name": "Barrels Before Alligator Cutscene",
+        "name": "Barrels before Alligator Cutscene",
         "region": "Sewers Entrance",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1462,7 +1462,7 @@
         "folder_path": "RopewayContents/World/Location_CrocodiliaArea/LocationLevel_CrocodiliaArea/Item/common/Leon_common"
     },
     {
-        "name": "At Water Gate",
+        "name": "Trash by Wall of Water",
         "region": "Upper Waterway",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1471,7 +1471,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
-        "name": "In Front of Gate",
+        "name": "Trash beside Gate",
         "region": "Upper Waterway",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -1481,7 +1481,7 @@
     },
     {
         "name": "Downed Zombie",
-        "region": "Upper Waterway",
+        "region": "Waterway Overpass",
         "original_item": "USS Digital Video Cassette",
         "condition": {},    
         "item_object": "sm73_405",
@@ -1507,7 +1507,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Gunpowder"
     },
     {
-        "name": "Down Elevator",
+        "name": "Ride the Elevator",
         "region": "Workers Break Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1535,7 +1535,7 @@
     },
     {
         "name": "Before the Waterslide",
-        "region": "Lower Waterway",
+        "region": "Waterway Overpass",
         "original_item": "Combat Knife",
         "condition": {},    
         "item_object": "WP4500",
@@ -1642,8 +1642,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Downstairs Location",
-        "region": "Treatment Pool Room",
+        "name": "On Boxes near Stairs",
+        "region": "Central Hub",
         "original_item": "Green Herb",
         "condition": {},    
         "item_object": "sm70_001",
@@ -1651,8 +1651,8 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "End of Left Path",
-        "region": "Lower Waterway",
+        "name": "On Ledge in Water by Trash",
+        "region": "Central Hub",
         "original_item": "Hand Grenade",
         "condition": {},    
         "item_object": "WP6200",
@@ -1696,15 +1696,6 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/KeyItem"
     },
     {
-        "name": "Rook Panel Outside",
-        "region": "Workroom",
-        "original_item": "Rook Plug",
-        "condition": {},    
-        "item_object": "sm73_115",
-        "parent_object": "ItemPositions_1",
-        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
-    },
-    {
         "name": "Right Table",
         "region": "Workroom",
         "original_item": "Large-Caliber Handgun Ammo",
@@ -1714,8 +1705,17 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/HundGun"
     },
     {
+        "name": "Rook Panel",
+        "region": "Waterway Overpass",
+        "original_item": "Rook Plug",
+        "condition": {},    
+        "item_object": "sm73_115",
+        "parent_object": "ItemPositions_1",
+        "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_611_0/gimmick"
+    },
+    {
         "name": "Keys Panel",
-        "region": "Treatment Pool Room",
+        "region": "Bottom Waterway",
         "original_item": "Sewers Key",
         "condition": {},    
         "item_object": "sm73_429",
@@ -1732,7 +1732,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/green_herb"
     },
     {
-        "name": "Left of 2nd Mutant",
+        "name": "Ledge after 2nd Mutant",
         "region": "Bottom Waterway",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1787,7 +1787,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common"
     },
     {
-        "name": "Stairs After Chess Puzzle",
+        "name": "Stairs after Chess Puzzle",
         "region": "Main Power Room",
         "original_item": "Blue Herb",
         "condition": {},    
@@ -1814,7 +1814,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 1",
+        "name": "Pile of Metal",
         "region": "Proposed Water Purification Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -1823,7 +1823,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Leon_common/G2Area_Leon"
     },
     {
-        "name": "Location 2",
+        "name": "Next to Crane Switch",
         "region": "Proposed Water Purification Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -1832,7 +1832,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 3",
+        "name": "On Barrel",
         "region": "Proposed Water Purification Room",
         "original_item": "Flash Grenade",
         "condition": {},    
@@ -1841,7 +1841,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/G2Area"
     },
     {
-        "name": "Location 4",
+        "name": "Stabbed into Sack",
         "region": "Proposed Water Purification Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -1962,7 +1962,7 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/StartArea/NapRoom",
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
-	{
+    {
         "name": "Next to Soldier",
         "region": "Main Shaft",
         "original_item": "Signal Modulator",
@@ -1993,7 +1993,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Ivy Room Before",
+        "name": "Ivy Area before Control Room",
         "region": "Greenhouse Control Room",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -2020,8 +2020,7 @@
         "item_object": "sm42_222_SprayingMachine01A_control",
         "parent_object": "",
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/LocationFsm_Laboratory/S05_0100/T_Area/ControlRoom/SanpuSouchiTrue_CONV366,367,368_CF707",
-        "forbid_item": ["Sewers Key", "T-Bar Handle"],
-        "randomized": 0
+        "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
         "name": "Before Drug Testing Lab",
@@ -2064,7 +2063,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Down Ladder Before Lounge",
+        "name": "Down Ladder before Lounge",
         "region": "Lounge - Labs",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2074,7 +2073,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Bench By Entrance",
+        "name": "Bench by Entrance",
         "region": "Lounge - Labs",
         "original_item": "Shotgun Shells",
         "condition": {},    
@@ -2084,7 +2083,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Benches Across the Room",
+        "name": "Benches across the Room",
         "region": "Lounge - Labs",
         "original_item": "Green Herb",
         "condition": {},    
@@ -2094,7 +2093,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Door",
+        "name": "Boxes by Door",
         "region": "Lobby Storage",
         "original_item": "High-Grade Gunpowder - Yellow",
         "condition": {},    
@@ -2114,7 +2113,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Across from Robot Arm",
+        "name": "Table across from Robot Arm",
         "region": "Low-Temp Testing Lab",
         "original_item": "Gunpowder",
         "condition": {},    
@@ -2123,7 +2122,7 @@
         "folder_path": "RopewayContents/World/Location_Laboratory/LocationLevel_Laboratory/Item/common/T_Area/LowTempatureRoom",
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
-	{
+    {
         "name": "Table near Entrance",
         "region": "Low-Temp Testing Lab",
         "original_item": "Trophy B",
@@ -2144,7 +2143,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "On Cart By Laptop",
+        "name": "On Cart by Laptop",
         "region": "Server Room",
         "original_item": "Combat Knife",
         "condition": {},    
@@ -2154,7 +2153,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Shelves Left of Typewriter",
+        "name": "Shelves left of Typewriter",
         "region": "Server Room",
         "original_item": "Flamethrower Fuel",
         "condition": {},    
@@ -2217,7 +2216,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Cart By Doorway",
+        "name": "Cart by Doorway",
         "region": "P-4 Level Testing Lab",
         "original_item": "Gunpowder - Large",
         "condition": {},    
@@ -2247,7 +2246,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 1",
+        "name": "Table right of Elevator 1",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2267,7 +2266,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Left of Entrance",
+        "name": "1st Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "First Aid Spray",
         "condition": {},    
@@ -2277,7 +2276,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Left of Entrance",
+        "name": "2nd Table left of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2287,7 +2286,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "1st Table Right of Entrance",
+        "name": "1st Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2297,7 +2296,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Table Right of Elevator 2",
+        "name": "Table right of Elevator 2",
         "region": "Bioreactors Room",
         "original_item": "Large-Caliber Handgun Ammo",
         "condition": {},    
@@ -2327,7 +2326,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "2nd Table Right of Entrance",
+        "name": "2nd Table right of Entrance",
         "region": "Bioreactors Room",
         "original_item": "MAG Ammo",
         "condition": {},    
@@ -2417,7 +2416,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Final Battle By Item Box",
+        "name": "Final Battle by Item Box",
         "region": "Path to Super Tyrant",
         "original_item": "Red Herb",
         "condition": {},    

--- a/residentevil2remake/data/leon/b/locations_hardcore.json
+++ b/residentevil2remake/data/leon/b/locations_hardcore.json
@@ -27,7 +27,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/1F/1FW/DarkRoom/Locker_sm70_100_HandgunB_HardInkribbon"
     },
     {
-        "name": "Table By Door",
+        "name": "Table by Door",
         "region": "East Office",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -63,7 +63,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
     {
-        "name": "Chair Across Room",
+        "name": "Chair across Room",
         "region": "Interrogation Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -81,7 +81,7 @@
         "folder_path": "RopewayContents/World/Location_RPD/LocationLevel_RPD/Item/common/InkRibbon"
     },
     {
-        "name": "Barrels Before Alligator Cutscene",
+        "name": "Barrels before Alligator Cutscene",
         "region": "Sewers Entrance",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -108,7 +108,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Trash Can By Saving Ada",
+        "name": "Trash Can by Saving Ada",
         "region": "Main Power Room",
         "original_item": "Ink Ribbon",
         "condition": {},    
@@ -147,7 +147,7 @@
         "forbid_item": ["Sewers Key", "T-Bar Handle"]
     },
     {
-        "name": "Boxes By Typewriter",
+        "name": "Boxes by Typewriter",
         "region": "Path to Super Tyrant",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/leon/b/region_connections.json
+++ b/residentevil2remake/data/leon/b/region_connections.json
@@ -394,6 +394,11 @@
     },
     { 
         "from": "Upper Waterway",
+        "to": "Waterway Overpass",
+        "condition": {}
+    },
+    { 
+        "from": "Waterway Overpass",
         "to": "Workers Break Room",
         "condition": {
             "items": ["Sewers Key"]
@@ -407,19 +412,19 @@
     },
     { 
         "from": "Workroom",
-        "to": "Upper Waterway",
+        "to": "Waterway Overpass",
         "condition": {},
         "limitation": "ONE_SIDED_DOOR"
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Water Injection Chamber",
         "condition": {
             "items": ["Sewers Key"]
         }
     },
     { 
-        "from": "Upper Waterway",
+        "from": "Waterway Overpass",
         "to": "Lower Waterway",
         "condition": {}
     },
@@ -447,6 +452,17 @@
     },
     { 
         "from": "Treatment Pool Room",
+        "to": "Central Hub",
+        "condition": {}
+    },
+    { 
+        "from": "Central Hub",
+        "to": "Lower Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
+    },
+    { 
+        "from": "Central Hub",
         "to": "Bottom Waterway",
         "condition": {
             "items": ["T-Bar Handle"]
@@ -455,7 +471,22 @@
     { 
         "from": "Bottom Waterway",
         "to": "Supplies Storage Room",
-        "condition": {}
+        "condition": {
+            "items": ["Queen Plug"]
+        }
+    },
+    { 
+        "from": "Upper Waterway",
+        "to": "Bottom Waterway",
+        "condition": {
+            "items": ["T-Bar Handle"]
+        }
+    }, 
+    { 
+        "from": "Bottom Waterway",
+        "to": "Upper Waterway",
+        "condition": {},
+        "limitation": "ONE_SIDED_DOOR"
     },
     { 
         "from": "Monitor Room",

--- a/residentevil2remake/data/leon/b/regions.json
+++ b/residentevil2remake/data/leon/b/regions.json
@@ -293,6 +293,14 @@
         "name": "Bottom Waterway",
         "zone_id": 3
     },
+    {
+        "name": "Waterway Overpass",
+        "zone_id": 3
+    },
+    {
+        "name": "Central Hub",
+        "zone_id": 3
+    },
     
     {
         "name": "Cable Car Platform",


### PR DESCRIPTION
Renames some of the locations so that they aren't relative to cardinal directions on a map and hopefully makes the rest easier to discern from looking at their names via !missing commands or while using Universal Tracker.

Adds in a new region called `Waterway Overpass` that is the connecting hub for Upper Waterway, Workroom, Worker's Break Room and the Water Injection Chamber. This now acts as the `Downed Zombie` (Video Cassette), the `Before the Waterslide` and the `Rook Panel Outside` (now named Rook Panel) region in the sewers, which should also help clear up a logic bug on Claire's side. 

Adds in a new region called `Central Hub` that is the connecting hub for Treatment Pool Room, Lower Waterway and Bottom Waterway. This now acts as the `Downstairs Location` (now named `On Boxes near Stairs`) and 'End of Left Path' (now named `On Ledge in Water by Trash`) region in the sewers. 

`Keys Panel` now properly has it's `Bottom Waterway` region, which should fix the bug mentioned above where `T-Bar Handle` could've been locked behind itself.

This also randomizes `Dispersal Cartridge - Empty` into the pool, and will have client side changes to accompany it. 

Also some slight fixes to bullet count on a couple weapons for Claire, and gives the `GM 79` a single round for count instead of the usual 0 in vanilla due to instances where the player might receive it as their starting weapon.