### PR TITLE
Support Assisted difficulty

### DIFF
--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -22,10 +22,11 @@ class Scenario(Choice):
 class Difficulty(Choice):
     """Standard: Most people should play on this.
     Hardcore: Good luck, and thanks for testing deaths. Kappa
-    Assisted: No. Do Standard."""
+    Assisted: ... Okay, fine. No judgment here. :)"""
     display_name = "Difficulty to Play On"
     option_standard = 0
     option_hardcore = 1
+    option_assisted = 2
     default = 0
 
 class UnlockedTypewriters(OptionList):


### PR DESCRIPTION
From testing, our awesome community found out that Assisted difficulty has the same checks as Standard difficulty. So, this PR just adds the option to choose Assisted, and rolls everything the same as it would with Standard.