### PR TITLE
Fix Hardcore + Add Valve Handle as a condition for Victory

### DIFF
--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -2374,8 +2374,8 @@
         "region": "Path to G4",
         "condition": {
             "items": [
-                "Spade Key", "Heart Key", "Diamond Key",
-                "Bolt Cutters", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Spade Key", "Heart Key", "Diamond Key", 
+                "Bolt Cutters", "Valve Handle", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", 
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/residentevil2remake/data/claire/a/locations_hardcore.json
+++ b/residentevil2remake/data/claire/a/locations_hardcore.json
@@ -99,7 +99,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2", 
+        "name": "On Table 2", 
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -576,10 +576,8 @@
         "condition": {}
     },
     { 
-        "from": "Path to G4",
-        "to": "G5 Ending",
-        "condition": {
-            "items": ["Joint Plug"]
-        }
+        "from": "Bioreactors Room",
+        "to": "Path to G4",
+        "condition": {}
     }
 ]

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -576,8 +576,10 @@
         "condition": {}
     },
     { 
-        "from": "Bioreactors Room",
-        "to": "Path to G4",
-        "condition": {}
+        "from": "Path to G4",
+        "to": "G5 Ending",
+        "condition": {
+            "items": ["Joint Plug"]
+        }
     }
 ]

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -2512,7 +2512,7 @@
         "condition": {
             "items": [
                 "Courtyard Key", "Spade Key", "Heart Key", "Diamond Key",
-                "Bolt Cutters", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
                 "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/residentevil2remake/data/claire/b/locations_hardcore.json
+++ b/residentevil2remake/data/claire/b/locations_hardcore.json
@@ -108,7 +108,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2", 
+        "name": "On Table 2", 
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -608,7 +608,7 @@
         "to": "Path to G4",
         "condition": {}
     },
-	{ 
+    { 
         "from": "Path to G4",
         "to": "G5 Ending",
         "condition": {

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -2405,7 +2405,7 @@
         "condition": {
             "items": [
                 "Spade Key", "Club Key", "Diamond Key",
-                "Bolt Cutters", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion", 
                 "Square Crank", "Fuse - Break Room Hallway", "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/residentevil2remake/data/leon/a/locations_hardcore.json
+++ b/residentevil2remake/data/leon/a/locations_hardcore.json
@@ -90,7 +90,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -2479,7 +2479,7 @@
         "condition": {
             "items": [
                 "Courtyard Key", "Spade Key", "Club Key", "Diamond Key",
-                "Bolt Cutters", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
+                "Bolt Cutters", "Valve Handle", "Fuse - Main Hall", "Lion Medallion", "Unicorn Medallion", "Maiden Medallion",
                 "Square Crank", "Mechanic Jack Handle", "Small Gear", "Large Gear", 
                 "Boxed Electronic Part 1", "Boxed Electronic Part 2", "Parking Garage Key Card",
                 "T-Bar Handle", "Pawn Plug", "Knight Plug", "Bishop Plug", "Rook Plug", "Queen Plug", "King Plug", 

--- a/residentevil2remake/data/leon/b/locations_hardcore.json
+++ b/residentevil2remake/data/leon/b/locations_hardcore.json
@@ -99,7 +99,7 @@
         "folder_path": "RopewayContents/World/Location_WasteWater/LocationLevel_WasteWater/Item/common/Inkribbon"
     },
     {
-        "name": "Table Location 2",
+        "name": "On Table 2",
         "region": "Water Injection Chamber",
         "original_item": "Ink Ribbon",
         "condition": {},    


### PR DESCRIPTION
Renames location in Hardcore to mirror it's Standard counterpart in all scenarios, and adds Valve Handle as a condition to Victory in all scenarios. 