### PR TITLE
Forced Knife on chair in Break Room in B scenarios to help with G1 fight

### DIFF
--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1184,6 +1184,7 @@
         "name": "Chair",
         "region": "Break Room",
         "original_item": "Fuse - Main Hall",
+        "force_item": "Combat Knife",
         "condition": {},    
         "item_object": "sm73_723",
         "parent_object": "sm73_723_fuse2",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1147,6 +1147,7 @@
         "name": "Chair",
         "region": "Break Room",
         "original_item": "Fuse - Main Hall",
+        "force_item": "Combat Knife",
         "condition": {},    
         "item_object": "sm73_723",
         "parent_object": "sm73_723_fuse2",


### PR DESCRIPTION
We've had complaints before that the G1 fight in B scenarios can be too difficult because there's no guaranteed knife like in A scenarios. This PR forces a Knife to be placed on the Break Room chair, which has the following benefits:

- Location is early enough that it's unlikely to be missed
- Players that don't "want the help" know the specific location that they can skip getting, if they want to