### PR TITLE
Fix chess plug panels for B scenarios

### DIFF
--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1611,8 +1611,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "Rook_sm42_215_PlugPlace02A_control",
-        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
+        "item_object": "Knight_sm42_215_PlugPlace02A_control",
+        "parent_object": "Knight_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1620,8 +1620,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "King_sm42_215_PlugPlace02A_control",
-        "parent_object": "King_sm42_215_PlugPlace02A_control",
+        "item_object": "Bishop_sm42_215_PlugPlace02A_control",
+        "parent_object": "Bishop_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1590,8 +1590,8 @@
         "region": "Monitor Room",
         "original_item": "Knight Plug",
         "condition": {},    
-        "item_object": "Rook_sm42_215_PlugPlace02A_control",
-        "parent_object": "Rook_sm42_215_PlugPlace02A_control",
+        "item_object": "Knight_sm42_215_PlugPlace02A_control",
+        "parent_object": "Knight_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {
@@ -1599,8 +1599,8 @@
         "region": "Monitor Room",
         "original_item": "Bishop Plug",
         "condition": {},    
-        "item_object": "King_sm42_215_PlugPlace02A_control",
-        "parent_object": "King_sm42_215_PlugPlace02A_control",
+        "item_object": "Bishop_sm42_215_PlugPlace02A_control",
+        "parent_object": "Bishop_sm42_215_PlugPlace02A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_632_0/gimmick"
     },
     {


### PR DESCRIPTION
In B scenarios only, the name of the panels that hold the Knight and Bishop plugs are different, which prevented sending the items on these locations. This PR updates those names.