### PR TITLE
Enemy fixes

### DIFF
--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -42,7 +42,7 @@ class ResidentEvil2Remake(World):
 
     data_version = 2
     required_client_version = (0, 5, 0)
-    apworld_release_version = "0.3.3" # defined to show in spoiler log
+    apworld_release_version = "0.3.4" # defined to show in spoiler log
 
     item_id_to_name = { item['id']: item['name'] for item in Data.item_table }
     item_name_to_id = { item['name']: item['id'] for item in Data.item_table }

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -4,8 +4,8 @@ import typing
 from typing import Dict, Any, TextIO
 from Utils import visualize_regions
 
-from BaseClasses import ItemClassification, Item, Location, Region, CollectionState, LocationProgressType
-from worlds.AutoWorld import World
+from BaseClasses import ItemClassification, Item, Location, Region, CollectionState, LocationProgressType, Tutorial
+from worlds.AutoWorld import World, WebWorld
 from ..generic.Rules import set_rule
 from Fill import fill_restrictive
 
@@ -19,6 +19,17 @@ Data.load_data('leon', 'a')
 Data.load_data('leon', 'b')
 Data.load_data('claire', 'a')
 Data.load_data('claire', 'b')
+
+class RPDNet(WebWorld):
+    theme = "partyTime"
+    tutorials = [Tutorial(
+        "Multiworld Setup Guide",
+        "A guide for setting up Resident Evil 2 Remake to be played in Archipelago.",
+        "English",
+        "setup_en.md",
+        "setup/en",
+        ["TheRealSolidusSnake"]
+    )]
 
 
 class RE2RLocation(Location):
@@ -62,6 +73,7 @@ class ResidentEvil2Remake(World):
 
     options_dataclass = RE2ROptions
     options: RE2ROptions
+    web = RPDNet()
 
     def generate_early(self): # check weapon randomization before locations and items are processed, so we can swap non-randomized items as well
         # check for option values that UT passed via storing from slot data, and set our options to match if present

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -28,7 +28,7 @@ class RPDNet(WebWorld):
         "English",
         "setup_en.md",
         "setup/en",
-        ["TheRealSolidusSnake"]
+        ["FuzzyGamesOn"]
     )]
 
 

--- a/residentevil2remake/archipelago.json
+++ b/residentevil2remake/archipelago.json
@@ -1,1 +1,0 @@
-{"game": "Resident Evil 2 Remake", "world_version": "0.3.4", "compatible_version": 7, "version": 7}

--- a/residentevil2remake/archipelago.json
+++ b/residentevil2remake/archipelago.json
@@ -1,0 +1,1 @@
+{"game": "Resident Evil 2 Remake", "world_version": "0.3.3", "compatible_version": 7, "version": 7}

--- a/residentevil2remake/archipelago.json
+++ b/residentevil2remake/archipelago.json
@@ -1,1 +1,1 @@
-{"game": "Resident Evil 2 Remake", "world_version": "0.3.3", "compatible_version": 7, "version": 7}
+{"game": "Resident Evil 2 Remake", "world_version": "0.3.4", "compatible_version": 7, "version": 7}

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -1011,7 +1011,10 @@
             "original_item": "",
             "item_object": "IvyZombie_Idle",
             "parent_object": "3-433-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["ID Wristband - Senior Staff"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -359,7 +359,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -373,7 +373,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -387,7 +387,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -400,8 +400,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -423,7 +423,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -437,7 +437,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -451,7 +451,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -464,8 +464,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -479,7 +479,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -493,7 +493,7 @@
             "condition": {
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -521,10 +521,7 @@
             "parent_object": "16-112-0-0-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Mechanic Jack Handle"]
             }
     },
     {
@@ -535,10 +532,7 @@
             "parent_object": "16-112-0-0-ID200",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Mechanic Jack Handle"]
             }
     },
     {
@@ -551,7 +545,7 @@
 			"condition": {
 				"items": [
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
 				]
 			}
 	},
@@ -564,8 +558,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
                 ]
             }
     },
@@ -593,6 +587,14 @@
             "parent_object": "25-408-0-1-ID000",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Zombie Dog behind fence",
+			"region": "RPD Streets",
+			"original_item": "",
+			"item_object": "em4000_Fence_01",
+			"parent_object": "25-408-0-4-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
     {
             "name": "Action Dog on white car",
             "region": "RPD Streets",
@@ -1035,6 +1037,14 @@
             "parent_object": "21-134-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Ivy 3 after elevator",
+			"region": "Path to G4",
+			"original_item": "",
+			"item_object": "Ivy_03",
+			"parent_object": "21-134-0-7-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
     {
             "name": "Falling Ivy 1",
             "region": "Path to G4",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -14,7 +14,8 @@
             "item_object": "emZombie1FE2Window",
             "parent_object": "16-239-0-0-ID017",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+			},
+            "excluded": 1
     {
             "name": "Blonde Zombie",
             "region": "East Hallway 1F",
@@ -46,6 +47,7 @@
             "item_object": "emZombie1FW2Window",
             "parent_object": "16-225-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Overweight Zombie at Vending Machines",
@@ -86,6 +88,7 @@
             "item_object": "emZombie1FW1Window",
             "parent_object": "16-226-0-0-ID016",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Roaming Zombie on West Stairwell",
@@ -145,6 +148,7 @@
             "item_object": "emZombie_2FECorrider",
 			"parent_object": "16-255-0-0-ID012",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -153,6 +157,7 @@
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
     },
 	{
 			"name": "Second Zombie from Window",
@@ -163,7 +168,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Wandering Zombie",
@@ -172,6 +178,7 @@
 			"item_object": "emZombie_1FEOffice2",
 			"parent_object": "16-230-0-0-ID203",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
 	},
 	{
 			"name": "First Zombie from Window",
@@ -180,6 +187,7 @@
 			"item_object": "emZombie_1FEOffice_Window",
 			"parent_object": "16-230-0-0-ID207",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"excluded": 1
 	},
 	{
 			"name": "First Zombie from South Window",
@@ -190,7 +198,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Roaming Jumpsuit Zombie",
@@ -212,7 +221,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
 	},
 	{
 			"name": "Roaming High Visibility Zombie",
@@ -348,7 +358,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Diamond Key"]
-            }
+            },
+			"excluded": 1
 	},
     {
             "name": "Dark Police Zombie",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -464,8 +464,8 @@
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": [
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack 	Handle"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
 				]
 			}
 	},

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -104,7 +104,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Hanging Zombie after using Detonator",
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -131,7 +131,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie-Eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -162,7 +162,7 @@
 			"parent_object": "16-239-0-0-ID003",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Bolt Cutters"]
+                "items": ["Maiden Medallion"]
 			}
 	},
 	{
@@ -248,6 +248,29 @@
 			}
 	},
     {
+            "name": "Licker outside STARS Office",
+            "region": "STARS Office",
+            "original_item": "",
+            "item_object": "FirstLicker",
+            "parent_object": "16-253-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Maiden Medallion"]
+            }
+    },
+    {
+            "name": "Licker that loves explosions",
+            "region": "West Storage Room",
+            "original_item": "",
+            "item_object": "emLicker_3FLickerRoomA",
+            "parent_object": "16-265-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Battery", "Electronic Gadget"]
+            },
+            "excluded": 1
+    },
+    {
             "type": "Boss",
             "name": "G1 Boss Fight",
             "region": "Machinery Room",
@@ -327,28 +350,6 @@
             }
 	},
     {
-            "name": "Bald Police Zombie from Window",
-            "region": "Observation Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FE1Window",
-            "parent_object": "16-240-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-    {
-            "name": "Jump Scare Licker",
-            "region": "Interrogation Room",
-            "original_item": "",
-            "item_object": "1FEInterrogationRoom_Licker",
-            "parent_object": "16-233-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
             "name": "Dark Police Zombie",
             "region": "East Storage Room",
             "original_item": "",
@@ -377,21 +378,111 @@
             }
     },
     {
-            "name": "Female Zombie outside of Boiler Room",
-            "region": "Roof",
+            "name": "Bald Police Zombie from Window",
+            "region": "Observation Room Hallway",
             "original_item": "",
-            "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-1-ID002",
+            "item_object": "emZombie1FE1Window",
+            "parent_object": "16-240-0-0-ID213",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+            "name": "Jump Scare Licker",
+            "region": "Interrogation Room",
+            "original_item": "",
+            "item_object": "1FEInterrogationRoom_Licker",
+            "parent_object": "16-233-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Male Zombie outside of Boiler Room",
-            "region": "Roof",
+			"name": "Second Zombie from South Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW4Window3rd",
+			"parent_object": "16-125-0-0-ID012",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+			"name": "Second Zombie from Center Window",   
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window3rd",
+			"parent_object": "16-225-0-0-ID011",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+            "name": "Licker outside West Office",
+            "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-431-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
     },
+    {
+			"name": "Licker in blocked passage",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emLicker_1FW2-2",
+			"parent_object": "16-125-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack 	Handle"]
+				]
+			}
+	},
+	{
+			"name": "Licker",
+			"region": "West Storage Room",
+			"original_item": "",
+			"item_object": "emLicker_3FW2-2",
+			"parent_object": "16-265-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
     {
             "name": "Zombie Marvin",
             "region": "Main Hall",
@@ -407,18 +498,20 @@
             }
     },
     {
-            "name": "Licker outside West Office",
-            "region": "West Hallway 1F",
+            "name": "Female Zombie outside of Boiler Room",
+            "region": "Roof",
             "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-431-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
+            "item_object": "emZombie_OutdoorNorth",
+            "parent_object": "16-122-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Male Zombie outside of Boiler Room",
+            "region": "Roof",
+            "original_item": "",
+            "item_object": "emZombie_OutdoorNorth",
+            "parent_object": "16-122-0-0-ID004",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "Plain Clothes Zombie",
@@ -445,6 +538,34 @@
                 "items": [
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
+            }
+    },
+    {
+			"name": "Second Zombie from Window",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice_Window",
+			"parent_object": "16-230-0-0-ID007",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": [
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+				]
+			}
+	},
+    {
+            "name": "Third Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FEWindow3rd",
+            "parent_object": "16-239-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
     },
@@ -527,124 +648,6 @@
             "item_object": "em4000_Last_01",
             "parent_object": "25-408-0-4-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Third Zombie from Window",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FEWindow3rd",
-            "parent_object": "16-239-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-    {
-            "name": "Plaid Shirt Zombie",
-            "region": "Press Room",
-            "original_item": "",
-            "item_object": "emZombie_1FECorriderB",
-            "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
-    {
-            "name": "Second Zombie from Window",
-            "region": "East Office",
-            "original_item": "",
-            "item_object": "emZombie_1FEOffice_Window",
-            "parent_object": "16-230-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-		},
-        {
-            "name": "Second Zombie from South Window",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW4Window3rd",
-            "parent_object": "16-125-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-		},
-        {
-            "name": "Second Zombie from Center Window",   
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window3rd",
-            "parent_object": "16-225-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-		},
-        {
-            "name": "Licker in blocked passage",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-125-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-		},
-		{
-			"name": "Licker outside STARS Office",
-			"region": "STARS Office",
-			"original_item": "",
-			"item_object": "FirstLicker",
-			"parent_object": "16-253-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-		},
-		   {
-			"name": "Licker outside West Storage Room",
-			"region": "West Hallway 3F",
-			"original_item": "",
-			"item_object": "emLicker_3FW2-2",
-			"parent_object": "16-265-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-			"condition": {
-				"items": [
-          ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-        ]
-			}
-		},
-        {
-            "name": "Licker near Maiden Statue",
-            "region": "West Storage Room",
-            "original_item": "",
-            "item_object": "emLicker_3FLickerRoomA",
-            "parent_object": "16-265-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Battery", "Electronic Gadget"]
-            },
-            "excluded": 1
     },
     {
             "name": "Zombie by Lockers",
@@ -852,7 +855,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie in bed",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -879,7 +882,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -887,22 +890,22 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
             "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
-            "name": "Ivy the Fourth",
+    {
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
             "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-       {
+    {
             "name": "Short Hair Lab Coat Zombie",
             "region": "Lounge - Labs",
             "original_item": "",
@@ -978,20 +981,26 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
         {
-            "name": "First Ivy near basement ladder",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
         {
-            "name": "Ivy No. 5",
+            "name": "Second Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "name": "Surprise Ivy leaving Greenhouse",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -160,7 +160,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FE2Window2nd",
 			"parent_object": "16-239-0-0-ID003",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Bolt Cutters"]
 			}
@@ -187,7 +187,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FW4Window",
 			"parent_object": "16-125-0-0-ID211",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
 			}
@@ -198,7 +198,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FW3Window_Add",
 			"parent_object": "16-225-0-0-ID008",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Maiden Medallion"]
 			}
@@ -209,7 +209,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FW_Knock",
 			"parent_object": "16-225-0-1-ID003",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
 			}
@@ -220,7 +220,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FWAdd",
 			"parent_object": "16-225-0-2-ID004",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
 			}
@@ -231,7 +231,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FW3Window_BreakIn",
 			"parent_object": "16-225-0-1-ID012",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
 			}
@@ -242,7 +242,7 @@
 			"original_item": "",
 			"item_object": "emZombie1FW1Window2nd",
 			"parent_object": "16-226-0-0-ID014",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
 				"items": ["Maiden Medallion"]
 			}
@@ -321,7 +321,7 @@
 			"original_item": "",
 			"item_object": "Riccer_04",
 			"parent_object": "29-272-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Diamond Key"]
             }
@@ -536,8 +536,10 @@
             "parent_object": "16-239-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
                 ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
             }
     },
     {
@@ -548,8 +550,10 @@
             "parent_object": "16-232-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                "items": [
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
                 ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+                ]
             }
     },
     {
@@ -624,8 +628,10 @@
 			"parent_object": "16-265-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+				"items": [
+          ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
 					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+        ]
 			}
 		},
         {
@@ -995,7 +1001,7 @@
             "parent_object": "3-433-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "type": "Boss",
             "name": "G3 Boss Fight",
             "region": "Bioreactors Room",
@@ -1004,7 +1010,7 @@
             "parent_object": "3-419-0-15-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "name": "Ivy 1 after elevator",
             "region": "Path to G4",
             "original_item": "",
@@ -1036,7 +1042,7 @@
             "parent_object": "21-135-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-        {
+    {
             "name": "That Random Escape Zombie",
             "region": "Path to G4",
             "original_item": "",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -301,7 +301,8 @@
             "original_item": "",
             "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Licker eating Zombie Dog",
@@ -1075,6 +1076,9 @@
             "original_item": "",
             "item_object": "G4",
             "parent_object": "21-421-0-16-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -1,14 +1,14 @@
 [
     {
-            "name": "Police Zombie at Elliot",
+            "name": "Police Zombie after Elliot",
             "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1stDoorBan",
-            "parent_object": "16-239-0-0-ID213",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"item_object": "emZombie_1stDoorBan",
+			"parent_object": "16-239-0-0-ID213",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window",
@@ -32,7 +32,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie in Closet",
+            "name": "Overweight Zombie",
             "region": "East Hallway 1F Closet",
             "original_item": "",
             "item_object": "emZombie_DepotLate",
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie from Operations Room Window",
+            "name": "First Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW2Window",
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "First Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window",
@@ -88,15 +88,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of Stairs",
-            "region": "West Hallway 3F",
+            "name": "Roaming Zombie on West Stairwell",
+            "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
             "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of Stairs",
+            "name": "Police Zombie sitting at top of Stairs",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -104,7 +104,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Hanging Zombie after using Detonator",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -112,10 +112,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Battery", "Electronic Gadget"]
-            }
+			}
     },
     {
-            "name": "Female Zombie near Spade Door",
+            "name": "Female Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library_4",
@@ -123,7 +123,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -139,36 +139,121 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
+            "name": "First Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+			"parent_object": "16-255-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
+	{
+			"name": "Second Zombie from Window",
+			"region": "East Hallway 1F",
+			"original_item": "",
+			"item_object": "emZombie1FE2Window2nd",
+			"parent_object": "16-239-0-0-ID003",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Bolt Cutters"]
+			}
+	},
+	{
+			"name": "Wandering Zombie",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice2",
+			"parent_object": "16-230-0-0-ID203",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
+	{
+			"name": "First Zombie from Window",
+			"region": "East Office",
+			"original_item": "",
+			"item_object": "emZombie_1FEOffice_Window",
+			"parent_object": "16-230-0-0-ID207",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
+	{
+			"name": "First Zombie from South Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW4Window",
+			"parent_object": "16-125-0-0-ID211",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Roaming Jumpsuit Zombie",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window_Add",
+			"parent_object": "16-225-0-0-ID008",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "First Zombie from Center Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW_Knock",
+			"parent_object": "16-225-0-1-ID003",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Roaming High Visibility Zombie",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FWAdd",
+			"parent_object": "16-225-0-2-ID004",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
+	{
+			"name": "Second Zombie from North Window",
+			"region": "Southwest Hallway",
+			"original_item": "",
+			"item_object": "emZombie1FW3Window_BreakIn",
+			"parent_object": "16-225-0-1-ID012",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},	
     {
-            "name": "Helicopter Crash Zombie 2",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "2nd Zombie at Stairs",
-            "region": "West Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FW1Window2nd",
-            "parent_object": "16-226-0-0-ID014",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+			"name": "Second Zombie from Window",
+			"region": "West Hallway 1F",
+			"original_item": "",
+			"item_object": "emZombie1FW1Window2nd",
+			"parent_object": "16-226-0-0-ID014",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+				"items": ["Maiden Medallion"]
+			}
+	},
     {
             "type": "Boss",
             "name": "G1 Boss Fight",
             "region": "Machinery Room",
             "original_item": "",
             "item_object": "G1",
-            "parent_object": "29-353-1-12-nil",
+            "parent_object": "29-353-0-12-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -188,15 +273,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker outside of Kennel Room",
+            "name": "Licker on far wall",
             "region": "Kennel",
             "original_item": "",
-            "item_object": "Riccer_04",
+            "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker eating zombie dog",
+            "name": "Licker eating Zombie Dog",
             "region": "Kennel",
             "original_item": "",
             "item_object": "Riccer_03",
@@ -212,7 +297,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at Door",
+            "name": "Zombie sitting behind Door",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
@@ -220,7 +305,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
@@ -230,8 +315,19 @@
                 "items": ["Diamond Key"]
             }
     },
+	{
+			"name": "Licker on ceiling",
+			"region": "Kennel",
+			"original_item": "",
+			"item_object": "Riccer_04",
+			"parent_object": "29-272-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Diamond Key"]
+            }
+	},
     {
-            "name": "Bald Police Zombie",
+            "name": "Bald Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -245,7 +341,7 @@
             }
     },
     {
-            "name": "Interrogation Room Licker",
+            "name": "Jump Scare Licker",
             "region": "Interrogation Room",
             "original_item": "",
             "item_object": "1FEInterrogationRoom_Licker",
@@ -433,17 +529,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie from window",
+            "name": "Third Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FEWindow3rd",
             "parent_object": "16-239-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
             }
     },
     {
@@ -454,11 +548,12 @@
             "parent_object": "16-232-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Film - Hiding Place"]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+                ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
             }
     },
     {
-            "name": "Jumpsuit Zombie from office or window",
+            "name": "Second Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -470,9 +565,9 @@
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
-    },
+		},
         {
-            "name": "Plain Clothes Zombie from first Window",
+            "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -484,20 +579,9 @@
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
-    },
+		},
         {
-            "name": "Jumpsuit Zombie",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window_Add",
-            "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Maiden Medallion"]
-            }
-    },
-        {
-            "name": "Plain Clothes Zombie from mid Window",   
+            "name": "Second Zombie from Center Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window3rd",
@@ -509,28 +593,9 @@
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
-    },
-       {
-            "name": "2nd Blonde Zombie from Operations Room Window",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW3Window_BreakIn",
-            "parent_object": "16-225-0-1-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-       {
-            "name": "Overweight Zombie wearing Vest",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FWAdd",
-            "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Maiden Medallion"]
-            }
-    },
+		},
         {
-            "name": "Licker at start of hallway",
+            "name": "Licker in blocked passage",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW2-2",
@@ -542,29 +607,27 @@
                     ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
                 ]
             }
-    },
-    {
-            "name": "Licker outside STARS Office",
-            "region": "STARS Office",
-            "original_item": "",
-            "item_object": "FirstLicker",
-            "parent_object": "16-253-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-       {
-            "name": "Licker outside West Storage Room",
-            "region": "West Hallway 3F",
-            "original_item": "",
-            "item_object": "emLicker_3FW2-2",
-            "parent_object": "16-265-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
-    },
+		},
+		{
+			"name": "Licker outside STARS Office",
+			"region": "STARS Office",
+			"original_item": "",
+			"item_object": "FirstLicker",
+			"parent_object": "16-253-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+		},
+		   {
+			"name": "Licker outside West Storage Room",
+			"region": "West Hallway 3F",
+			"original_item": "",
+			"item_object": "emLicker_3FW2-2",
+			"parent_object": "16-265-0-3-nil",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
+					["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
+			}
+		},
         {
             "name": "Licker near Maiden Statue",
             "region": "West Storage Room",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -53,7 +53,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -61,7 +62,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Standing Police Zombie",
@@ -69,7 +71,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Dark-Haired Zombie",
@@ -197,7 +200,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -205,7 +209,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Cop in the South Side of the Hallway",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -586,7 +586,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall", "Diamond Key"]
             }
     },
     {

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -97,7 +97,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway 1F",
+            "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW",
             "parent_object": "16-125-0-3-nil",
@@ -139,7 +139,7 @@
             "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1FW1Window2nd",
+            "item_object": "emZombie1FW1Window2nd",
             "parent_object": "16-226-0-0-ID014",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
@@ -156,7 +156,7 @@
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
-            "parent_object": "16-253-0-0-ID200",
+            "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -208,10 +208,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Zombie from South Window",
+            "name": "Cop in the South Side of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW4Window",
+            "item_object": "emZombie1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -219,10 +219,10 @@
             }
     },
     {
-            "name": "First Zombie from Center Window",
+            "name": "Jumpsuit Zombie in the Center of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW3Window",
+            "item_object": "emZombie1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -233,7 +233,7 @@
             "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FWAdd",
+            "item_object": "emZombie1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -305,7 +305,7 @@
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
-            "parent_object": "29-273-0-2-ID004",
+            "parent_object": "29-273-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -480,7 +480,7 @@
             "region": "Roof",
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-1-ID004",
+            "parent_object": "16-122-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 		        "items": [
@@ -493,7 +493,7 @@
             "region": "Roof",
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
-            "parent_object": "16-122-0-0-ID002",
+            "parent_object": "16-122-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 				"items": [
@@ -515,7 +515,7 @@
             }
     },
     {
-            "name": "Second Zombie from South Window",
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -528,10 +528,10 @@
             }
     },
     {
-            "name": "Second Zombie from Center Window",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombieFW3Window3rd",
+            "item_object": "emZombie1FW3Window3rd",
             "parent_object": "16-225-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -542,7 +542,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emLicker_1FW2-2",
             "parent_object": "16-431-0-3-nil",
@@ -637,7 +637,8 @@
             "original_item": "",
             "item_object": "em0100_Start_01",
             "parent_object": "25-408-0-1-ID000",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog on White Car",
@@ -847,7 +848,7 @@
             "region": "Supplies Storage Room",
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
-            "parent_object": "17-327-0-0-ID008",
+            "parent_object": "17-327-0-2-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -1053,7 +1054,8 @@
             "original_item": "",
             "item_object": "ZombieTAreaLowTemperature",
             "parent_object": "3-414-0-1-ID304",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Lab Coat Zombie at bottom of stairs",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -129,7 +129,7 @@
     },
     {
             "name": "Police Zombie Playing Dead",
-            "region": "East Hallway 1F",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
             "parent_object": "16-431-0-0-ID213",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -48,7 +48,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "2nd Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -136,7 +136,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW1Window2nd",
@@ -192,15 +192,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Helicopter Crash Zombie 2",
+            "name": "First Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -208,12 +200,23 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first window",
+            "name": "Second Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+            "parent_object": "16-255-0-0-ID216",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Police Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            },
     },
     {
             "name": "Jumpsuit Zombie",
@@ -222,14 +225,20 @@
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            },
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            },
     },
     {
             "type": "Boss",
@@ -237,7 +246,7 @@
             "region": "Machinery Room",
             "original_item": "",
             "item_object": "G1",
-            "parent_object": "29-353-1-12-nil",
+            "parent_object": "29-353-0-12-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
 	{
@@ -247,6 +256,9 @@
 			"item_object": "Riccer_04",
 			"parent_object": "29-272-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Diamond Key"]
+            },
 	},
 	{
 			"name": "Licker at end of Hallway",
@@ -303,9 +315,6 @@
             "item_object": "Zombie_02_JumpUp",
             "parent_object": "29-273-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Diamond Key"]
-            }
     },
     {
             "name": "Plain Clothes Zombie",
@@ -316,7 +325,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            }
+            },
     },
     {
             "name": "Police Zombie",
@@ -327,7 +336,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            }
+            },
     },
     {
             "name": "Short-Haired Police Zombie",
@@ -337,8 +346,8 @@
             "parent_object": "16-269-0-0-ID214",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
-            }
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
+            },
     },
     {
             "name": "Dark Police Zombie",
@@ -348,8 +357,8 @@
             "parent_object": "16-269-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
-            }
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
+            },
     },
     {
             "name": "Police Zombie through window",
@@ -359,8 +368,8 @@
             "parent_object": "16-240-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion"]
-            }
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+            },
     },
     {
             "name": "Male Zombie outside Boiler Room",
@@ -369,6 +378,9 @@
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-1-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "condition": {
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+            },
     },
     {
             "name": "Female Zombie outside Boiler Room",
@@ -377,18 +389,20 @@
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-0-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "condition": {
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+            },
     },
 	{
-			"name": "Licker at Maiden Statue",
+			"name": "Licker",
 			"region": "West Storage Room",
 			"original_item": "",
 			"item_object": "emLicker_3FW2-2",
 			"parent_object": "16-265-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Battery", "Electronic Gadget"]
+				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
             },
-            "excluded": 1
 	},
     {
             "name": "Hanging Zombie After It Drops",
@@ -399,7 +413,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Battery", "Electronic Gadget"]
-            }
+            },
     },
     {
             "name": "Plain Zombie from window",
@@ -409,8 +423,8 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-            }
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
+            },
     },
 	{
 			"name": "Zombie banging on gate",
@@ -606,7 +620,6 @@
             "condition": {
                 "items": ["T-Bar Handle"]
             },
-            "excluded": 1
     },
     {
             "name": "Downed Plain Zombie",
@@ -663,6 +676,9 @@
 			"item_object": "emLicker_1FW2-2",
 			"parent_object": "16-431-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Skylight Licker",
@@ -671,6 +687,9 @@
 			"item_object": "emLicker_2FEArtRoomLicker",
 			"parent_object": "16-256-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Scepter"]
+            },
 	},
 	{
 			"name": "Peeping Tom-bie",
@@ -679,6 +698,9 @@
 			"item_object": "emZombie_1FECorriderB",
 			"parent_object": "16-232-0-0-ID011",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Interrogator Licker",
@@ -695,6 +717,9 @@
 			"item_object": "emLicker_1FW2-2",
 			"parent_object": "16-125-0-3-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Southwest Hallway 3rd Window Zombie",
@@ -703,6 +728,9 @@
 			"item_object": "emZombieFW3Window3rd",
 			"parent_object": "16-225-0-0-ID011",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Southwest Hallway 1st Window Zombie",
@@ -711,6 +739,9 @@
 			"item_object": "emZombie1FW4Window3rd",
 			"parent_object": "16-125-0-0-ID012",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Overalls Zombie East Office Window",
@@ -719,6 +750,9 @@
 			"item_object": "emZombie_1FEOffice_Window",
 			"parent_object": "16-230-0-0-ID007",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Female Zombie through window by East Office",
@@ -727,12 +761,9 @@
 			"item_object": "emZombie1FEWindow3rd",
 			"parent_object": "16-239-0-1-ID002",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "conditions": {
-                "items": [
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"],
-                    ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Mechanic Jack Handle"]
-                ]
-            }
+            "condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Dark Clothes Zombie East Hallway",
@@ -741,6 +772,9 @@
 			"item_object": "emZombie_1FECorridorC",
 			"parent_object": "16-229-0-0-ID209",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Plaid Shirt Zombie East Hallway",
@@ -749,6 +783,9 @@
 			"item_object": "emZombie_1FECorridorC",
 			"parent_object": "16-229-0-0-ID011",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Snacking Zombie",
@@ -757,6 +794,9 @@
 			"item_object": "emZombie_1FECorridorC",
 			"parent_object": "16-229-0-0-ID208",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
 	{
 			"name": "Dark Clothes Zombie from Window",
@@ -766,8 +806,8 @@
 			"parent_object": "16-229-0-0-ID207",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-            }
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+            },
 	},
     {
             "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
@@ -859,7 +899,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Signal Modulator"]
-            }
+            },
     },
     {
             "name": "First Ivy before puzzle",
@@ -918,12 +958,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
 	{
-			"name": "Ivy in Disperal Room",
+			"name": "Surprise Ivy",
 			"region": "Greenhouse Control Room",
 			"original_item": "",
 			"item_object": "IvyZombie_Idle",
 			"parent_object": "3-433-0-7-nil",
 			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["ID Wristband - Senior Staff"]
+            },
 	},
     {
             "name": "Short Hair Lab Coat Zombie",
@@ -990,7 +1033,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Signal Modulator"]
-            }
+            },
     },
     {
             "name": "Stunt Zombie from stairs above",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -326,7 +326,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },	
@@ -339,7 +339,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },
@@ -352,7 +352,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },
@@ -365,7 +365,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key", "Fuse - Main Hall"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key", "Fuse - Main Hall"]
 				]
             }
     },	
@@ -586,7 +586,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle", "Fuse - Main Hall"]
             }
     },
     {

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -266,7 +266,8 @@
             "original_item": "",
             "item_object": "Riccer_01",
             "parent_object": "29-272-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Licker eating Dog",
@@ -1165,6 +1166,9 @@
             "original_item": "",
             "item_object": "G5",
             "parent_object": "21-423-0-17-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -215,7 +215,7 @@
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -226,7 +226,7 @@
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-				"items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+				"items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -237,7 +237,7 @@
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -698,9 +698,8 @@
             "parent_object": "16-256-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Scepter"]
+                "items": ["Red Book", "Statue Left Arm"]
             }
-			"exclude": 1
     },
     {
             "name": "Peeping Tom-bie",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -213,10 +213,10 @@
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
-            },
+            }
     },
     {
             "name": "Jumpsuit Zombie",
@@ -224,10 +224,10 @@
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
-            },
+				"items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            }
     },
     {
             "name": "High Visibility Zombie",
@@ -235,10 +235,10 @@
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
-            },
+            }
     },
     {
             "type": "Boss",
@@ -249,41 +249,41 @@
             "parent_object": "29-353-0-12-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-	{
-			"name": "Licker on Ceiling",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_04",
-			"parent_object": "29-272-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
+    {
+		    "name": "Licker on Ceiling",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_04",
+            "parent_object": "29-272-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
                 "items": ["Diamond Key"]
-            },
-	},
-	{
-			"name": "Licker at end of Hallway",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_01",
-			"parent_object": "29-272-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Licker eating Dog",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_03",
-			"parent_object": "29-279-0-3-nil",
+            }
+    },
+    {
+            "name": "Licker at end of Hallway",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_01",
+            "parent_object": "29-272-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Licker behind cages",
-			"region": "Kennel",
-			"original_item": "",
-			"item_object": "Riccer_02",
-			"parent_object": "29-279-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    },
+    {
+            "name": "Licker eating Dog",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_03",
+            "parent_object": "29-279-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Licker behind cages",
+            "region": "Kennel",
+            "original_item": "",
+            "item_object": "Riccer_02",
+            "parent_object": "29-279-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "Overweight Zombie",
             "region": "Firing Range",
@@ -314,7 +314,7 @@
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
             "parent_object": "29-273-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "Plain Clothes Zombie",
@@ -325,7 +325,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            },
+            }
     },
     {
             "name": "Police Zombie",
@@ -336,7 +336,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            },
+            }
     },
     {
             "name": "Short-Haired Police Zombie",
@@ -347,7 +347,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            },
+            }
     },
     {
             "name": "Dark Police Zombie",
@@ -358,7 +358,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
 				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
-            },
+            }
     },
     {
             "name": "Police Zombie through window",
@@ -368,8 +368,10 @@
             "parent_object": "16-240-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
-            },
+				"items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
     },
     {
             "name": "Male Zombie outside Boiler Room",
@@ -377,10 +379,12 @@
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-1-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
-            },
+		        "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
     },
     {
             "name": "Female Zombie outside Boiler Room",
@@ -388,22 +392,26 @@
             "original_item": "",
             "item_object": "emZombie_OutdoorNorth",
             "parent_object": "16-122-0-0-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
-            },
+				"items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+            }
     },
-	{
-			"name": "Licker",
-			"region": "West Storage Room",
-			"original_item": "",
-			"item_object": "emLicker_3FW2-2",
-			"parent_object": "16-265-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+    {
+            "name": "Licker",
+            "region": "West Storage Room",
+            "original_item": "",
+            "item_object": "emLicker_3FW2-2",
+            "parent_object": "16-265-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-				"items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
-            },
-	},
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				]
+              }
+    },
     {
             "name": "Hanging Zombie After It Drops",
             "region": "West Storage Room",
@@ -413,7 +421,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Battery", "Electronic Gadget"]
-            },
+            }
     },
     {
             "name": "Plain Zombie from window",
@@ -424,128 +432,128 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
-            },
+            }
     },
-	{
-			"name": "Zombie banging on gate",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Fence_Door",
-			"parent_object": "25-406-0-0-ID305",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Zombie with plaid shirt",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Fence_01",
-			"parent_object": "25-406-0-0-ID014",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Misty by the dumpster",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Start_01",
-			"parent_object": "25-408-0-1-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Zombie Dog behind fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Fence_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Second Dog behind Fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0100_Start_01",
-			"parent_object": "25-408-0-1-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog on White Car",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Start_02",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog having a snack",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Eat_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog 1 jumping fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Action Dog 2 jumping fence",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_02",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog before bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Court_03",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Another one rides the bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em0000_Bus_02",
-			"parent_object": "25-408-0-0-ID000",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Dog after bus",
-			"region": "RPD Streets",
-			"original_item": "",
-			"item_object": "em4000_Last_01",
-			"parent_object": "25-408-0-4-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Short hair zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_03",
-			"parent_object": "17-330-0-0-ID019",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Overweight zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_05",
-			"parent_object": "17-330-0-2-ID002",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Shorter hair zombie",
-			"region": "Control Room",
-			"original_item": "",
-			"item_object": "Zombie_Waste02_04",
-			"parent_object": "17-330-2-0-ID020",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    {
+            "name": "Zombie banging on gate",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Fence_Door",
+            "parent_object": "25-406-0-0-ID305",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Zombie with plaid shirt",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Fence_01",
+            "parent_object": "25-406-0-0-ID014",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Misty by the dumpster",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Start_01",
+            "parent_object": "25-408-0-1-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Zombie Dog behind fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Fence_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Dog behind Fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0100_Start_01",
+            "parent_object": "25-408-0-1-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog on White Car",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Start_02",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog having a snack",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Eat_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog 1 jumping fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Action Dog 2 jumping fence",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_02",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog before bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Court_03",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Another one rides the bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em0000_Bus_02",
+            "parent_object": "25-408-0-0-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Dog after bus",
+            "region": "RPD Streets",
+            "original_item": "",
+            "item_object": "em4000_Last_01",
+            "parent_object": "25-408-0-4-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Short hair zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_03",
+            "parent_object": "17-330-0-0-ID019",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Overweight zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_05",
+            "parent_object": "17-330-0-2-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Shorter hair zombie",
+            "region": "Control Room",
+            "original_item": "",
+            "item_object": "Zombie_Waste02_04",
+            "parent_object": "17-330-2-0-ID020",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "Blue Jumpsuit Zombie",
             "region": "Waterway Overpass",
@@ -619,7 +627,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["T-Bar Handle"]
-            },
+            }
     },
     {
             "name": "Downed Plain Zombie",
@@ -661,154 +669,177 @@
             "parent_object": "17-325-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-	{
-			"name": "G-Adult upper waterway",
-			"region": "Upper Waterway",
-			"original_item": "",
-			"item_object": "em6000_07",
-			"parent_object": "17-315-0-8-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "West Hallway Licker",
-			"region": "West Hallway",
-			"original_item": "",
-			"item_object": "emLicker_1FW2-2",
-			"parent_object": "16-431-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Skylight Licker",
-			"region": "Art Room",
-			"original_item": "",
-			"item_object": "emLicker_2FEArtRoomLicker",
-			"parent_object": "16-256-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
+    {
+            "name": "G-Adult upper waterway",
+            "region": "Upper Waterway",
+            "original_item": "",
+            "item_object": "em6000_07",
+            "parent_object": "17-315-0-8-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "West Hallway Licker",
+            "region": "West Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-431-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Skylight Licker",
+            "region": "Art Room",
+            "original_item": "",
+            "item_object": "emLicker_2FEArtRoomLicker",
+            "parent_object": "16-256-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
                 "items": ["Scepter"]
-            },
-	},
-	{
-			"name": "Peeping Tom-bie",
-			"region": "Press Room",
-			"original_item": "",
-			"item_object": "emZombie_1FECorriderB",
-			"parent_object": "16-232-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Interrogator Licker",
-			"region": "Interrogation Room",
-			"original_item": "",
-			"item_object": "1FEInterrogationRoom_Licker",
-			"parent_object": "16-233-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Southwest Hallway Licker 2",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emLicker_1FW2-2",
-			"parent_object": "16-125-0-3-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Southwest Hallway 3rd Window Zombie",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emZombieFW3Window3rd",
-			"parent_object": "16-225-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Southwest Hallway 1st Window Zombie",
-			"region": "Southwest Hallway",
-			"original_item": "",
-			"item_object": "emZombie1FW4Window3rd",
-			"parent_object": "16-125-0-0-ID012",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Overalls Zombie East Office Window",
-			"region": "East Office",
-			"original_item": "",
-			"item_object": "emZombie_1FEOffice_Window",
-			"parent_object": "16-230-0-0-ID007",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Female Zombie through window by East Office",
-			"region": "East Hallway 1F",
-			"original_item": "",
-			"item_object": "emZombie1FEWindow3rd",
-			"parent_object": "16-239-0-1-ID002",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            }
+			"exclude": 1
+    },
+    {
+            "name": "Peeping Tom-bie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Dark Clothes Zombie East Hallway",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID209",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Plaid Shirt Zombie East Hallway",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID011",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Snacking Zombie",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC",
-			"parent_object": "16-229-0-0-ID208",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
-	{
-			"name": "Dark Clothes Zombie from Window",
-			"region": "Break Room Hallway",
-			"original_item": "",
-			"item_object": "emZombie_1FECorridorC_Window",
-			"parent_object": "16-229-0-0-ID207",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Interrogator Licker",
+            "region": "Interrogation Room",
+            "original_item": "",
+            "item_object": "1FEInterrogationRoom_Licker",
+            "parent_object": "16-233-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Southwest Hallway Licker 2",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-125-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-            },
-	},
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Southwest Hallway 3rd Window Zombie",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombieFW3Window3rd",
+            "parent_object": "16-225-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Southwest Hallway 1st Window Zombie",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombie1FW4Window3rd",
+            "parent_object": "16-125-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Overalls Zombie East Office Window",
+            "region": "East Office",
+            "original_item": "",
+            "item_object": "emZombie_1FEOffice_Window",
+            "parent_object": "16-230-0-0-ID007",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Female Zombie through window by East Office",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FEWindow3rd",
+            "parent_object": "16-239-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Dark Clothes Zombie East Hallway",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID209",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Plaid Shirt Zombie East Hallway",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Snacking Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID208",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Dark Clothes Zombie from Window",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC_Window",
+            "parent_object": "16-229-0-0-ID207",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
     {
             "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
             "region": "Bottom Waterway",
@@ -899,7 +930,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Signal Modulator"]
-            },
+            }
     },
     {
             "name": "First Ivy before puzzle",
@@ -958,15 +989,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
 	{
-			"name": "Surprise Ivy",
-			"region": "Greenhouse Control Room",
-			"original_item": "",
-			"item_object": "IvyZombie_Idle",
-			"parent_object": "3-433-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
+            "name": "Surprise Ivy",
+            "region": "Greenhouse Control Room",
+            "original_item": "",
+            "item_object": "IvyZombie_Idle",
+            "parent_object": "3-433-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
                 "items": ["ID Wristband - Senior Staff"]
-            },
+            }
 	},
     {
             "name": "Short Hair Lab Coat Zombie",
@@ -1033,7 +1064,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Signal Modulator"]
-            },
+            }
     },
     {
             "name": "Stunt Zombie from stairs above",
@@ -1084,22 +1115,22 @@
             "parent_object": "21-134-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-	{
-			"name": "Ivy Air Drop",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "IvyZombie01",
-			"parent_object": "21-135-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
-	{
-			"name": "Ivy Air Drop 2",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "IvyZombie02",
-			"parent_object": "21-135-0-7-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-	},
+    {
+            "name": "Ivy Air Drop",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "IvyZombie01",
+            "parent_object": "21-135-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Ivy Air Drop 2",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "IvyZombie02",
+            "parent_object": "21-135-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
     {
             "name": "That Random Escape Zombie but on fire",
             "region": "Path to G4",
@@ -1110,12 +1141,12 @@
     },
     {
             "type": "Boss",
-			"name": "G4",
-			"region": "Path to G4",
-			"original_item": "",
-			"item_object": "G4",
-			"parent_object": "21-421-0-16-nil",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "name": "G4",
+            "region": "Path to G4",
+            "original_item": "",
+            "item_object": "G4",
+            "parent_object": "21-421-0-16-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -951,15 +951,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_AfterFall",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },    
-    {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -967,7 +959,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
@@ -975,7 +967,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy the Fourth",
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
@@ -983,12 +975,26 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy No. 5",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
+    },   
+    {
+            "name": "Second Ivy after using Dispersal Cartridge",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_AfterFall",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
 	{
             "name": "Surprise Ivy",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Elliot",
+            "name": "Elliot is half the man he used to be",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FEEliot",
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Marvin",
+            "name": "Marvin is just pranking us, right?",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_2ndMarvin",
@@ -88,7 +88,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie East Rail",
+            "name": "Female Zombie Upstairs",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_1FECorridor_DepotZombies",
@@ -128,7 +128,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -144,7 +144,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of stairs",
+            "name": "Police Zombie that loves Jumping",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -152,7 +152,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at end of corridor",
+            "name": "Zombie between floors",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
@@ -160,7 +160,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of stairs",
+            "name": "Surprise Zombie from Spade Key room",
             "region": "West Hallway 3F",
             "original_item": "",
             "item_object": "2ndPlaySpadekeyZombie",
@@ -176,7 +176,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -184,7 +184,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Key Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -208,7 +208,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie",
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
@@ -219,7 +219,7 @@
             }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
@@ -317,6 +317,84 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
+            "name": "Dark Police Zombie from Window",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC_Window",
+            "parent_object": "16-229-0-0-ID207",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Dark Police Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID209",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Plaid Shirt Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Munching Zombie",
+            "region": "Break Room Hallway",
+            "original_item": "",
+            "item_object": "emZombie_1FECorridorC",
+            "parent_object": "16-229-0-0-ID208",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Second Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FEWindow3rd",
+            "parent_object": "16-239-0-1-ID002",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },	
+    {
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
             "name": "Plain Clothes Zombie",
             "region": "Main Hall 3F",
             "original_item": "",
@@ -326,7 +404,7 @@
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
             }
-    },
+    },	
     {
             "name": "Police Zombie",
             "region": "Main Hall 3F",
@@ -336,6 +414,19 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"]
+            }
+    },
+    {
+            "name": "Second Zombie from Window",
+            "region": "East Office",
+            "original_item": "",
+            "item_object": "emZombie_1FEOffice_Window",
+            "parent_object": "16-230-0-0-ID007",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
             }
     },
     {
@@ -361,7 +452,7 @@
             }
     },
     {
-            "name": "Police Zombie through window",
+            "name": "Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -371,6 +462,17 @@
 				"items": [
 				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
 				]
+            }
+    },
+    {
+            "name": "Interrogator Licker",
+            "region": "Interrogation Room",
+            "original_item": "",
+            "item_object": "1FEInterrogationRoom_Licker",
+            "parent_object": "16-233-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
             }
     },
     {
@@ -400,6 +502,58 @@
             }
     },
     {
+            "name": "Second Licker",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-125-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Second Zombie from South Window",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombie1FW4Window3rd",
+            "parent_object": "16-125-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Second Zombie from Center Window",
+            "region": "Southwest Hallway",
+            "original_item": "",
+            "item_object": "emZombieFW3Window3rd",
+            "parent_object": "16-225-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
+            "name": "Licker",
+            "region": "West Hallway",
+            "original_item": "",
+            "item_object": "emLicker_1FW2-2",
+            "parent_object": "16-431-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": [
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
+				]
+            }
+    },
+    {
             "name": "Licker",
             "region": "West Storage Room",
             "original_item": "",
@@ -408,12 +562,12 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
+				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"]
 				]
               }
     },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -424,7 +578,7 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
@@ -432,6 +586,17 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion", "Small Gear", "Large Gear", "Mechanic Jack Handle"]
+            }
+    },
+    {
+            "name": "Skylight Licker",
+            "region": "Art Room",
+            "original_item": "",
+            "item_object": "emLicker_2FEArtRoomLicker",
+            "parent_object": "16-256-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Red Book", "Statue Left Arm"]
             }
     },
     {
@@ -654,7 +819,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Third G-Adult from sewer hole",
+            "name": "Third G-Adult from Sewer Pipe",
             "region": "Bottom Waterway",
             "original_item": "",
             "item_object": "em6000_Hole",
@@ -667,184 +832,6 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
             "parent_object": "17-325-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "G-Adult upper waterway",
-            "region": "Upper Waterway",
-            "original_item": "",
-            "item_object": "em6000_07",
-            "parent_object": "17-315-0-8-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "West Hallway Licker",
-            "region": "West Hallway",
-            "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-431-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Skylight Licker",
-            "region": "Art Room",
-            "original_item": "",
-            "item_object": "emLicker_2FEArtRoomLicker",
-            "parent_object": "16-256-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Red Book", "Statue Left Arm"]
-            }
-    },
-    {
-            "name": "Peeping Tom-bie",
-            "region": "Press Room",
-            "original_item": "",
-            "item_object": "emZombie_1FECorriderB",
-            "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Interrogator Licker",
-            "region": "Interrogation Room",
-            "original_item": "",
-            "item_object": "1FEInterrogationRoom_Licker",
-            "parent_object": "16-233-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Southwest Hallway Licker 2",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emLicker_1FW2-2",
-            "parent_object": "16-125-0-3-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Southwest Hallway 3rd Window Zombie",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombieFW3Window3rd",
-            "parent_object": "16-225-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Southwest Hallway 1st Window Zombie",
-            "region": "Southwest Hallway",
-            "original_item": "",
-            "item_object": "emZombie1FW4Window3rd",
-            "parent_object": "16-125-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Overalls Zombie East Office Window",
-            "region": "East Office",
-            "original_item": "",
-            "item_object": "emZombie_1FEOffice_Window",
-            "parent_object": "16-230-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Female Zombie through window by East Office",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie1FEWindow3rd",
-            "parent_object": "16-239-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Dark Clothes Zombie East Hallway",
-            "region": "Break Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie_1FECorridorC",
-            "parent_object": "16-229-0-0-ID209",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Plaid Shirt Zombie East Hallway",
-            "region": "Break Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie_1FECorridorC",
-            "parent_object": "16-229-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Snacking Zombie",
-            "region": "Break Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie_1FECorridorC",
-            "parent_object": "16-229-0-0-ID208",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Dark Clothes Zombie from Window",
-            "region": "Break Room Hallway",
-            "original_item": "",
-            "item_object": "emZombie_1FECorridorC_Window",
-            "parent_object": "16-229-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": [
-				["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Diamond Key", "Heart Key"], ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Mechanic Jack Handle", "Heart Key"]
-				]
-            }
-    },
-    {
-            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
-            "region": "Bottom Waterway",
-            "original_item": "",
-            "item_object": "Zombie_WasteGAdultArea_man01",
-            "parent_object": "17-325-0-0-ID024",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -869,6 +856,22 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
+            "region": "Bottom Waterway",
+            "original_item": "",
+            "item_object": "Zombie_WasteGAdultArea_man01",
+            "parent_object": "17-325-0-0-ID024",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "G-Adult upper waterway",
+            "region": "Upper Waterway",
+            "original_item": "",
+            "item_object": "em6000_07",
+            "parent_object": "17-315-0-8-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -921,7 +924,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dr Li",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -1115,7 +1118,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy Air Drop",
+            "name": "First Ivy Air Drop",
             "region": "Path to G4",
             "original_item": "",
             "item_object": "IvyZombie01",
@@ -1123,7 +1126,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy Air Drop 2",
+            "name": "Second Ivy Air Drop",
             "region": "Path to G4",
             "original_item": "",
             "item_object": "IvyZombie02",
@@ -1140,7 +1143,7 @@
     },
     {
             "type": "Boss",
-            "name": "G4",
+            "name": "G4 Boss Fight",
             "region": "Path to G4",
             "original_item": "",
             "item_object": "G4",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -150,7 +150,9 @@
         "region": "Press Room",
         "original_item": "Needle Cartridges",
         "condition": {
-            "items": ["Fuse - Main Hall", "Film - Hiding Place"]
+            "items": [
+			["Fuse - Main Hall", "Film - Hiding Place"], ["Spade Key", "Film - Hiding Place"]
+			]
         },    
         "item_object": "sm70_109",
         "parent_object": "ItemPos_TreasureA_Claire",

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -192,13 +192,13 @@
         }
     },
     { 
-        "from": "Main Hall",
-        "to": "Waiting Room",
+        "from": "Waiting Room",
+        "to": "Main Hall",
         "condition": {}
     },
     { 
-        "from": "Waiting Room",
-        "to": "East Hallway 2F",
+        "from": "East Hallway 2F",
+        "to": "Waiting Room",
         "condition": {
             "items": ["Spade Key"]
         }

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -13,7 +13,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window",
             "parent_object": "16-239-0-0-ID017",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Blonde Zombie",
@@ -45,7 +46,8 @@
             "original_item": "",
             "item_object": "emZombie1FW2Window",
             "parent_object": "16-225-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Overweight Zombie at Vending Machines",
@@ -85,7 +87,8 @@
             "original_item": "",
             "item_object": "emZombie1FW1Window",
             "parent_object": "16-226-0-0-ID016",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Roaming Zombie on West Stairwell",
@@ -144,7 +147,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
 			"parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -152,7 +156,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Zombie from Window",
@@ -163,7 +168,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			      "condition": {
                 "items": ["Maiden Medallion"]
-			}
+			},
+			"excluded": 1
     },
     {
             "name": "Wandering Zombie",
@@ -171,7 +177,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -179,7 +186,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from South Window",   
@@ -190,7 +198,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Maiden Medallion"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Roaming Jumpsuit Zombie",
@@ -212,7 +221,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Maiden Medallion"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Roaming High Visibility Zombie",
@@ -344,7 +354,8 @@
             "original_item": "",
             "item_object": "FenceClimbDog",
             "parent_object": "29-274-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog under fence outside door",
@@ -352,7 +363,8 @@
             "original_item": "",
             "item_object": "dog_East_twinsBlue1",
             "parent_object": "29-272-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -363,7 +375,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog from vent",
@@ -374,7 +387,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Dark Police Zombie",

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -1049,7 +1049,10 @@
             "original_item": "",
             "item_object": "NakedTyrant",
             "parent_object": "21-373-0-11-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 1",
@@ -1057,7 +1060,10 @@
             "original_item": "",
             "item_object": "EscpZombie05",
             "parent_object": "21-422-0-2-ID006",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 2",
@@ -1065,7 +1071,10 @@
             "original_item": "",
             "item_object": "EscpZombie03",
             "parent_object": "21-422-0-0-ID023",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 3",
@@ -1073,7 +1082,10 @@
             "original_item": "",
             "item_object": "EscpZombie06",
             "parent_object": "21-422-0-0-ID025",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 4",
@@ -1081,7 +1093,10 @@
             "original_item": "",
             "item_object": "EscpZombie02",
             "parent_object": "21-422-0-2-ID005",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 5",
@@ -1089,7 +1104,10 @@
             "original_item": "",
             "item_object": "EscpZombie04",
             "parent_object": "21-422-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 6",
@@ -1097,6 +1115,9 @@
             "original_item": "",
             "item_object": "EscpZombie01",
             "parent_object": "21-422-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     }
 ]

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -1,26 +1,10 @@
 [
     {
-            "name": "Dark-Haired Zombie",
+            "name": "Police Zombie after Elliot",
             "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_Depot1",
-            "parent_object": "16-239-0-0-ID006",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Blonde Zombie",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie_1FECorridor_DepotZombies",
-            "parent_object": "16-239-0-1-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Overweight Zombie",
-            "region": "East Hallway 1F Closet",
-            "original_item": "",
-            "item_object": "emZombie_DepotLate",
-            "parent_object": "16-231-0-2-ID202",
+            "item_object": "emZombie_1stDoorBan",
+            "parent_object": "16-239-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -32,34 +16,28 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Second Zombie from Window",
+            "name": "Blonde Zombie",
             "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie1FE2Window2nd",
-            "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-			      "condition": {
-                "items": ["Maiden Medallion"]
-			}
-    },
-    {
-            "name": "Police Zombie after Elliot",
-            "region": "East Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie_1stDoorBan",
-            "parent_object": "16-239-0-0-ID213",
+            "item_object": "emZombie_1FECorridor_DepotZombies",
+            "parent_object": "16-239-0-1-ID007",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Plaid Shirt Zombie",
-            "region": "Press Room",
+            "name": "Dark-Haired Zombie",
+            "region": "East Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1FECorriderB",
-            "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Film - Hiding Place"]
-            }
+            "item_object": "emZombie_Depot1",
+            "parent_object": "16-239-0-0-ID006",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Overweight Zombie",
+            "region": "East Hallway 1F Closet",
+            "original_item": "",
+            "item_object": "emZombie_DepotLate",
+            "parent_object": "16-231-0-2-ID202",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "First Zombie from North Window",
@@ -78,6 +56,14 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
+            "name": "Police Zombie Playing Dead",
+            "region": "West Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie_1FW_TrapZombie",
+            "parent_object": "16-431-0-0-ID213",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
             "name": "Sleeping Desk Zombie",
             "region": "West Office",
             "original_item": "",
@@ -91,14 +77,6 @@
             "original_item": "",
             "item_object": "emZombie_1FWestOffice",
             "parent_object": "16-119-0-0-ID208",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "One-Armed Police Zombie outside West Office",
-            "region": "West Hallway 1F",
-            "original_item": "",
-            "item_object": "emZombie_1FW_TrapZombie",
-            "parent_object": "16-431-0-0-ID213",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -126,6 +104,17 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
+            "name": "Zombie Hanging Around",
+            "region": "West Storage Room",
+            "original_item": "",
+            "item_object": "DeadZombie",
+            "parent_object": "16-265-0-0-ID000",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Battery", "Electronic Gadget"]
+            }
+    },
+    {
             "name": "Female Zombie",
             "region": "Library",
             "original_item": "",
@@ -142,7 +131,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie-Eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -164,6 +153,17 @@
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Zombie from Window",
+            "region": "East Hallway 1F",
+            "original_item": "",
+            "item_object": "emZombie1FE2Window2nd",
+            "parent_object": "16-239-0-0-ID003",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			      "condition": {
+                "items": ["Maiden Medallion"]
+			}
     },
     {
             "name": "Wandering Zombie",
@@ -269,17 +269,6 @@
                 "items": ["Battery", "Electronic Gadget"]
             },
             "excluded": 1
-    },
-    {
-            "name": "Hanging Zombie After It Drops",
-            "region": "West Storage Room",
-            "original_item": "",
-            "item_object": "DeadZombie",
-            "parent_object": "16-265-0-0-ID000",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Battery", "Electronic Gadget"]
-            }
     },
     {
             "type": "Boss",
@@ -456,6 +445,17 @@
             }
     },
     {
+            "name": "Peeping Zombie",
+            "region": "Press Room",
+            "original_item": "",
+            "item_object": "emZombie_1FECorriderB",
+            "parent_object": "16-232-0-0-ID011",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            }
+    },
+    {
             "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
@@ -560,7 +560,7 @@
             }
     },
     {
-            "name": "Dark Police Zombie from window",
+            "name": "Dark Police Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
@@ -574,7 +574,7 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
@@ -760,7 +760,7 @@
             "parent_object": "17-315-0-2-ID001",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Sewers Key"]
+                "items": ["T-Bar Handle"]
             },
             "excluded": 1
     },
@@ -846,7 +846,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie in bed",
+            "name": "Zombie outside Nap Room",
+            "region": "Nap Room",
+            "original_item": "",
+            "item_object": "ZombieNorth04",
+            "parent_object": "3-129-0-0-ID400",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",
@@ -857,11 +865,43 @@
             }
     },
     {
-            "name": "Zombie outside Nap Room",
-            "region": "Nap Room",
+            "name": "First Ivy before puzzle",
+            "region": "Greenhouse Control Room",
             "original_item": "",
-            "item_object": "ZombieNorth04",
-            "parent_object": "3-129-0-0-ID400",
+            "item_object": "IvyZombie_First",
+            "parent_object": "3-411-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Ivy before puzzle",
+            "region": "Greenhouse Control Room",
+            "original_item": "",
+            "item_object": "IvyZombie_FirstHang",
+            "parent_object": "3-411-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Idle",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Fall2",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Third Ivy",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_Fall1",
+            "parent_object": "3-410-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -921,30 +961,6 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Lab Coat Zombie",
-            "region": "Lobby Storage",
-            "original_item": "",
-            "item_object": "ZombieTArea01",
-            "parent_object": "3-413-0-1-ID302",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "First Ivy before puzzle",
-            "region": "Greenhouse Control Room",
-            "original_item": "",
-            "item_object": "IvyZombie_First",
-            "parent_object": "3-411-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Second Ivy before puzzle",
-            "region": "Greenhouse Control Room",
-            "original_item": "",
-            "item_object": "IvyZombie_FirstHang",
-            "parent_object": "3-411-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
             "name": "Ivy at the top of the stairs",
             "region": "Lobby Storage",
             "original_item": "",
@@ -956,44 +972,34 @@
             }
     },
     {
-            "name": "First Ivy near basement ladder",
+            "name": "Female Lab Coat Zombie",
+            "region": "Lobby Storage",
+            "original_item": "",
+            "item_object": "ZombieTArea01",
+            "parent_object": "3-413-0-1-ID302",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
-            "name": "Second Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Idle",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy in the middle",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Fall2",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy the Fourth",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_Fall1",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Ivy No. 5",
+            "name": "Second Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -16,7 +16,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie in Closet",
+            "name": "Overweight Zombie",
             "region": "East Hallway 1F Closet",
             "original_item": "",
             "item_object": "emZombie_DepotLate",
@@ -24,7 +24,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window",
@@ -32,15 +32,18 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "2nd Zombie from Elliot's Window",
+            "name": "Second Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Bolt Cutters"]
+			}
     },
     {
-            "name": "Police Zombie at Elliot",
+            "name": "Police Zombie after Elliot",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1stDoorBan",
@@ -59,7 +62,7 @@
             }
     },
     {
-            "name": "Female Zombie from Operations Room Window",
+            "name": "First Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW2Window",
@@ -99,7 +102,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "First Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window",
@@ -107,8 +110,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of Stairs",
-            "region": "West Hallway 3F",
+            "name": "Roaming Zombie on West Stairwell",
+            "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
             "parent_object": "16-226-1-0-ID009",
@@ -123,7 +126,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie near Spade Door",
+            "name": "Female Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library_4",
@@ -131,7 +134,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -147,7 +150,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
+            "name": "First Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+			"parent_object": "16-255-0-0-ID012",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Second Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -155,15 +166,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 2",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Standing Police Zombie",
+            "name": "Wandering Zombie",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
@@ -171,7 +174,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -179,7 +182,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first Window",   
+            "name": "First Zombie from South Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window",
@@ -190,7 +193,7 @@
             }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "Roaming Jumpsuit Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window_Add",
@@ -201,7 +204,7 @@
             }
     },
     {
-            "name": "Female Zombie from mid Window",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW_Knock",
@@ -212,7 +215,7 @@
             }
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "Roaming High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FWAdd",
@@ -223,7 +226,7 @@
             }
     },
     {
-            "name": "2nd Blonde Zombie from Operations Room Window",
+            "name": "Second Zombie from North Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window_BreakIn",
@@ -234,7 +237,7 @@
             }
     },
     {
-            "name": "2nd Zombie at Stairs",
+            "name": "Second Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FW1Window2nd",
@@ -256,7 +259,7 @@
             }
     },
     {
-            "name": "Licker near Maiden Statue",
+            "name": "Licker that loves explosions",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FLickerRoomA",
@@ -304,7 +307,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 1",
+            "name": "First Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage03Leon",
@@ -312,7 +315,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 2",
+            "name": "Second Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage02Leon",
@@ -320,7 +323,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Dog in Cage 3",
+            "name": "Third Dog in Cage",
             "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_Cage01Leon",
@@ -328,7 +331,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at Door",
+            "name": "Zombie sitting behind Door",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
@@ -336,7 +339,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
@@ -442,7 +445,7 @@
             }
     },
     {
-            "name": "Bald Police Zombie",
+            "name": "Bald Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -453,7 +456,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from first Window",
+            "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -464,7 +467,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from mid Window",   
+            "name": "Second Zombie from Center Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window3rd",
@@ -486,7 +489,7 @@
             }
     },
     {
-            "name": "Licker at start of hallway",
+            "name": "Licker in blocked passage",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW2-2",
@@ -497,8 +500,8 @@
             }
     },
     {
-            "name": "Licker outside West Storage Room",
-            "region": "West Hallway 3F",
+            "name": "Licker",
+            "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FW2-2",
             "parent_object": "16-265-0-3-nil",
@@ -578,14 +581,11 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Boxed Electronic Part 1"]
             }
     },
     {
-            "name": "Jumpsuit Zombie from office or window",
+            "name": "Second Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -596,7 +596,7 @@
             }
     },
     {
-            "name": "Female Zombie from window",
+            "name": "Third Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FEWindow3rd",
@@ -647,7 +647,7 @@
             "parent_object": "17-429-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -658,7 +658,7 @@
             "parent_object": "17-429-0-1-ID006",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -669,7 +669,7 @@
             "parent_object": "17-429-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -760,7 +760,7 @@
             "parent_object": "17-315-0-2-ID001",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["Sewers Key"]
             },
             "excluded": 1
     },

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -37,9 +37,9 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			"condition": {
-                "items": ["Bolt Cutters"]
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			      "condition": {
+                "items": ["Maiden Medallion"]
 			}
     },
     {

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -2393,7 +2393,9 @@
         "name": "Final Hit on Super Tyrant",
         "region": "Path to Super Tyrant",
         "original_item": "Anti-tank Rocket",
-        "condition": {},    
+        "condition": {
+            "items": ["Joint Plug"]
+        },
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -354,7 +354,7 @@
             "parent_object": "16-229-0-0-ID207",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -365,7 +365,7 @@
             "parent_object": "16-229-0-0-ID209",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -376,7 +376,7 @@
             "parent_object": "16-229-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {
@@ -601,7 +601,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
+                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion", "Fuse - Main Hall"]
             }
     },
     {

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -53,7 +53,8 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
             "parent_object": "16-239-0-0-ID003",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "First Zombie from Window",
@@ -61,7 +62,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
             "parent_object": "16-230-0-0-ID207",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Standing Police Zombie",
@@ -69,7 +71,8 @@
             "original_item": "",
             "item_object": "emZombie_1FEOffice2",
             "parent_object": "16-230-0-0-ID203",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Dark-Haired Zombie",
@@ -197,7 +200,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Second Helicopter Crash Zombie",
@@ -205,7 +209,8 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Cop in the South Side of the Hallway",
@@ -311,7 +316,8 @@
             "original_item": "",
             "item_object": "FenceClimbDog",
             "parent_object": "29-274-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Action Dog under fence outside door",
@@ -322,7 +328,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -333,7 +340,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Action Dog from vent",
@@ -344,7 +352,8 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            }
+            },
+			"excluded": 1
     },
     {
             "name": "Dark Police Zombie from Window",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -408,7 +408,7 @@
             "item_object": "emZombie_1FECorriderB",
             "parent_object": "16-232-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-			"conditions": {
+			"condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
             }
     },

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -1057,7 +1057,10 @@
             "original_item": "",
             "item_object": "NakedTyrant",
             "parent_object": "21-373-0-11-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 1",
@@ -1065,7 +1068,10 @@
             "original_item": "",
             "item_object": "EscpZombie05",
             "parent_object": "21-422-0-2-ID006",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 2",
@@ -1073,7 +1079,10 @@
             "original_item": "",
             "item_object": "EscpZombie03",
             "parent_object": "21-422-0-0-ID023",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 3",
@@ -1081,7 +1090,10 @@
             "original_item": "",
             "item_object": "EscpZombie06",
             "parent_object": "21-422-0-0-ID025",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 4",
@@ -1089,7 +1101,10 @@
             "original_item": "",
             "item_object": "EscpZombie02",
             "parent_object": "21-422-0-2-ID005",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 5",
@@ -1097,7 +1112,10 @@
             "original_item": "",
             "item_object": "EscpZombie04",
             "parent_object": "21-422-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "name": "Rocket Target Practice Zombie 6",
@@ -1105,7 +1123,10 @@
             "original_item": "",
             "item_object": "EscpZombie01",
             "parent_object": "21-422-0-0-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Joint Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -139,7 +139,7 @@
             "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emZombie_1FW1Window2nd",
+            "item_object": "emZombie1FW1Window2nd",
             "parent_object": "16-226-0-0-ID014",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
@@ -156,7 +156,7 @@
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
-            "parent_object": "16-253-0-0-ID200",
+            "parent_object": "16-226-1-0-ID009",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -208,10 +208,10 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "First Zombie from South Window",
+            "name": "Cop in the South Side of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW4Window",
+            "item_object": "emZombie1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -219,10 +219,10 @@
             }
     },
     {
-            "name": "First Zombie from Center Window",
+            "name": "Jumpsuit Zombie in the Center of the Hallway",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FW3Window",
+            "item_object": "emZombie1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -233,7 +233,7 @@
             "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emZombie_1FWAdd",
+            "item_object": "emZombie1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
@@ -294,7 +294,7 @@
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_01_OutSide",
-            "parent_object": "29-273-0-2-ID004",
+            "parent_object": "29-273-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -498,7 +498,7 @@
             "name": "Second Licker",
             "region": "Southwest Hallway",
             "original_item": "",
-            "item_object": "emLicker_1FW-2",
+            "item_object": "emLicker_1FW2-2",
             "parent_object": "16-125-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -971,7 +971,8 @@
             "original_item": "",
             "item_object": "ZombieTAreaLowTemperature",
             "parent_object": "3-414-0-1-ID304",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"excluded": 1
     },
     {
             "name": "Lab Coat Zombie at bottom of stairs",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -129,7 +129,7 @@
     },
     {
             "name": "Police Zombie Playing Dead",
-            "region": "East Hallway 1F",
+            "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
             "parent_object": "16-431-0-0-ID213",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -97,7 +97,7 @@
     },
     {
             "name": "Licker",
-            "region": "West Hallway 1F",
+            "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW",
             "parent_object": "16-125-0-3-nil",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -387,7 +387,7 @@
             "parent_object": "16-229-0-0-ID208",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank", "Fuse - Main Hall"]
             }
     },
     {

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -213,7 +213,7 @@
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
             }
@@ -224,7 +224,7 @@
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
             }
@@ -235,7 +235,7 @@
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
             }
@@ -319,7 +319,7 @@
             "original_item": "",
             "item_object": "dog_East_twinsBlue1",
             "parent_object": "29-272-0-4-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
             }
@@ -363,7 +363,7 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID209",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
             }
@@ -374,7 +374,7 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
             }
@@ -385,7 +385,7 @@
             "original_item": "",
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID208",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
                 "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
             }
@@ -399,7 +399,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
-            },
+            }
     },
     {
             "name": "Peeping Zombie",
@@ -407,7 +407,7 @@
             "original_item": "",
             "item_object": "emZombie_1FECorriderB",
             "parent_object": "16-232-0-0-ID011",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"conditions": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
             }
@@ -421,7 +421,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
-            },
+            }
     },
     {
             "name": "Police Zombie",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -878,17 +878,9 @@
             "item_object": "IvyZombie_FirstHang",
             "parent_object": "3-411-0-7-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
+    }, 
     {
-            "name": "First Ivy near basement ladder",
-            "region": "Greenhouse",
-            "original_item": "",
-            "item_object": "IvyZombie_AfterFall",
-            "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },    
-    {
-            "name": "Second Ivy near basement ladder",
+            "name": "First Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Idle",
@@ -896,7 +888,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy in the middle",
+            "name": "Second Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall2",
@@ -904,7 +896,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy the Fourth",
+            "name": "Third Ivy",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_Fall1",
@@ -912,12 +904,26 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Ivy No. 5",
+            "name": "First Ivy after using Dispersal Cartridge",
             "region": "Greenhouse",
             "original_item": "",
             "item_object": "IvyZombie_AfterFall",
             "parent_object": "3-410-0-7-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
+    },   
+    {
+            "name": "Second Ivy after using Dispersal Cartridge",
+            "region": "Greenhouse",
+            "original_item": "",
+            "item_object": "IvyZombie_AfterFall",
+            "parent_object": "3-410-0-7-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Signal Modulator", "Dispersal Cartridge - Empty"]
+            }
     },
     {
             "name": "Short Hair Lab Coat Zombie",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -80,7 +80,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Marvin",
+            "name": "Marvin is just pranking us, right?",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_2ndMarvin",
@@ -88,7 +88,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Female Zombie East Rail",
+            "name": "Female Zombie Upstairs",
             "region": "Main Hall",
             "original_item": "",
             "item_object": "emZombie_1FECorridor_DepotZombies",
@@ -128,7 +128,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "One-Armed Police Zombie outside West Office",
+            "name": "Police Zombie Playing Dead",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW_TrapZombie",
@@ -144,7 +144,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sitting Police Zombie at top of stairs",
+            "name": "Police Zombie that loves Jumping",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW",
@@ -152,7 +152,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at end of corridor",
+            "name": "Zombie between floors",
             "region": "West Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FW_CorriderB",
@@ -160,7 +160,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie at top of stairs",
+            "name": "Surprise Zombie from Spade Key room",
             "region": "West Hallway 3F",
             "original_item": "",
             "item_object": "2ndPlaySpadekeyZombie",
@@ -176,7 +176,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie eating Zombie",
+            "name": "Cannibal Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library3",
@@ -215,7 +215,7 @@
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -226,7 +226,7 @@
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -237,7 +237,7 @@
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"condition": {
-                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+                "items": ["Unicorn Medallion", "Maiden Medallion", "Lion Medallion"]
             }
     },
     {
@@ -391,7 +391,7 @@
             }
     },
     {
-            "name": "Female Zombie from window",
+            "name": "Second Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FEWindow3rd",
@@ -435,7 +435,7 @@
             }
     },
     {
-            "name": "Jumpsuit Zombie from office or window",
+            "name": "Second Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -468,7 +468,7 @@
             }
     },
     {
-            "name": "Bald Police Zombie window",
+            "name": "Police Zombie from Window",
             "region": "Observation Room Hallway",
             "original_item": "",
             "item_object": "emZombie1FE1Window",
@@ -495,7 +495,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Licker",
+            "name": "Second Licker",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emLicker_1FW-2",
@@ -506,7 +506,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from first Window",
+            "name": "Second Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW4Window3rd",
@@ -517,7 +517,7 @@
             }
     },
     {
-            "name": "Plain Clothes Zombie from mid Window",   
+            "name": "Second Zombie from Center Window",   
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie1FW3Window3rd",
@@ -579,11 +579,11 @@
             "parent_object": "16-265-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Square Crank"]
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
             }
     },
     {
-            "name": "Hanging Zombie After It Drops",
+            "name": "Zombie Hanging Around",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "DeadZombie",
@@ -594,14 +594,25 @@
             }
     },
     {
-            "name": "Plain Zombie from window",
+            "name": "Plain Zombie from Window",
             "region": "Break Room Hallway",
             "original_item": "",
             "item_object": "emZombie_1FECorridorC_Window",
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Small Gear", "Large Gear", "Square Crank", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
+                "items": ["Small Gear", "Large Gear", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
+            }
+    },
+    {
+            "name": "Skylight Licker",
+            "region": "Art Room",
+            "original_item": "",
+            "item_object": "emLicker_2FEArtRoomLicker",
+            "parent_object": "16-256-0-3-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Red Book", "Statue Left Arm"]
             }
     },
     {
@@ -677,12 +688,15 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
 	{
-			"name": "Falling Zombie",
+			"name": "Falling Overweight Zombie",
 			"region": "Waterway Overpass",
 			"original_item": "",
 			"item_object": "Zombie_Waste02_FallBefor",
 			"parent_object": "17-315-0-2-ID001",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+			"condition": {
+                "items": ["T-Bar Handle"]
+            }
 	},
     {
             "name": "Dark shirt Female Zombie",
@@ -742,7 +756,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Third G-Adult from sewer hole",
+            "name": "Third G-Adult from Sewer Pipe",
             "region": "Bottom Waterway",
             "original_item": "",
             "item_object": "em6000_Hole",
@@ -755,14 +769,6 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
             "parent_object": "17-325-0-2-ID004",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
-            "region": "Bottom Waterway",
-            "original_item": "",
-            "item_object": "Zombie_WasteGAdultArea_man01",
-            "parent_object": "17-325-0-0-ID024",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -787,6 +793,14 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",
+            "region": "Bottom Waterway",
+            "original_item": "",
+            "item_object": "Zombie_WasteGAdultArea_man01",
+            "parent_object": "17-325-0-0-ID024",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
@@ -839,7 +853,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleeping Zombie",
+            "name": "Sleepy Dr Li",
             "region": "Nap Room",
             "original_item": "",
             "item_object": "ZombieNorth01",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -40,7 +40,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie Elliot",
+            "name": "Elliot is half the man he used to be",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FEEliot",
@@ -48,7 +48,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "2nd Zombie from Elliot's Window",
+            "name": "First Zombie from Window",
             "region": "East Hallway 1F",
             "original_item": "",
             "item_object": "emZombie1FE2Window2nd",
@@ -56,7 +56,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window",
+            "name": "First Zombie from Window",
             "region": "East Office",
             "original_item": "",
             "item_object": "emZombie_1FEOffice_Window",
@@ -136,7 +136,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Zombie from Window at Stairs",
+            "name": "Zombie from Window",
             "region": "West Hallway 1F",
             "original_item": "",
             "item_object": "emZombie_1FW1Window2nd",
@@ -184,7 +184,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Overweight Zombie near Spade Key Door",
+            "name": "Overweight Zombie",
             "region": "Library",
             "original_item": "",
             "item_object": "emZombie_Library2",
@@ -192,15 +192,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Helicopter Crash Zombie 1",
-            "region": "East Hallway 2F",
-            "original_item": "",
-            "item_object": "emZombie_2FECorrider",
-            "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-    },
-    {
-            "name": "Helicopter Crash Zombie 2",
+            "name": "First Helicopter Crash Zombie",
             "region": "East Hallway 2F",
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
@@ -208,28 +200,45 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Police Zombie from first window",
+            "name": "Second Helicopter Crash Zombie",
+            "region": "East Hallway 2F",
+            "original_item": "",
+            "item_object": "emZombie_2FECorrider",
+            "parent_object": "16-255-0-0-ID216",
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+    },
+    {
+            "name": "First Zombie from South Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW4Window",
             "parent_object": "16-125-0-0-ID211",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            }
     },
     {
-            "name": "Jumpsuit Zombie",
+            "name": "First Zombie from Center Window",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FW3Window",
             "parent_object": "16-225-0-0-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            }
     },
     {
-            "name": "Overweight Zombie wearing Vest",
+            "name": "High Visibility Zombie",
             "region": "Southwest Hallway",
             "original_item": "",
             "item_object": "emZombie_1FWAdd",
             "parent_object": "16-225-0-2-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion, Maiden Medallion, Lion Medallion"]
+            }
     },
     {
             "type": "Boss",
@@ -289,15 +298,12 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
-            "name": "Sleepy Zombie at Diamond Key",
+            "name": "Sleepy Zombie with Diamond Key",
             "region": "Morgue",
             "original_item": "",
             "item_object": "Zombie_02_JumpUp",
             "parent_object": "29-273-0-0-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["Diamond Key"]
-            }
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {
             "name": "Action Dog behind fence",
@@ -309,11 +315,14 @@
     },
     {
             "name": "Action Dog under fence outside door",
-            "region": "Generator Room",
+            "region": "Kennel",
             "original_item": "",
             "item_object": "dog_East_twinsBlue1",
-            "parent_object": "29-273-0-4-nil",
+            "parent_object": "29-272-0-4-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "condition": {
+                "items": ["Square Crank"]
+            }
     },
     {
             "name": "Action Dog jumping over debris outside doors",
@@ -345,10 +354,7 @@
             "parent_object": "16-229-0-0-ID207",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
             }
     },
     {
@@ -358,6 +364,9 @@
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID209",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Plaid Shirt Zombie",
@@ -366,6 +375,9 @@
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Munching Zombie",
@@ -374,6 +386,9 @@
             "item_object": "emZombie_1FECorridorC",
             "parent_object": "16-229-0-0-ID208",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"condition": {
+                "items": ["Unicorn Medallion", "Lion Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Female Zombie from window",
@@ -384,15 +399,18 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
-            }
+            },
     },
     {
-            "name": "Zombie hitting door",
+            "name": "Peeping Zombie",
             "region": "Press Room",
             "original_item": "",
             "item_object": "emZombie_1FECorriderB",
             "parent_object": "16-232-0-0-ID011",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"conditions": {
+                "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
+            }
     },
     {
             "name": "Plain Clothes Zombie",
@@ -403,7 +421,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Lion Medallion", "Unicorn Medallion", "Maiden Medallion", "Square Crank"]
-            }
+            },
     },
     {
             "name": "Police Zombie",
@@ -513,7 +531,7 @@
             "name": "Licker",
             "region": "West Hallway 1F",
             "original_item": "",
-            "item_object": "emLicker_1FW-2",
+            "item_object": "emLicker_1FW2-2",
             "parent_object": "16-431-0-3-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
@@ -554,7 +572,7 @@
             }
     },
     {
-            "name": "Licker near Maiden Statue",
+            "name": "Licker",
             "region": "West Storage Room",
             "original_item": "",
             "item_object": "emLicker_3FW2-2",
@@ -562,8 +580,7 @@
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
                 "items": ["Square Crank"]
-            },
-            "excluded": 1
+            }
     },
     {
             "name": "Hanging Zombie After It Drops",
@@ -584,10 +601,7 @@
             "parent_object": "16-229-0-0-ID018",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": [
-                    ["Small Gear", "Large Gear", "Square Crank"],
-                    ["Small Gear", "Large Gear", "Mechanic Jack Handle"]
-                ]
+                "items": ["Small Gear", "Large Gear", "Square Crank", "Mechanic Jack Handle", "Lion Medallion", "Maiden Medallion", "Unicorn Medallion"]
             }
     },
     {
@@ -662,18 +676,14 @@
             "parent_object": "17-317-0-8-nil",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
-    {
-            "name": "Falling Overweight Zombie",
-            "region": "Waterway Overpass",
-            "original_item": "",
-            "item_object": "Zombie_Waste02_Fall",
-            "parent_object": "17-315-0-2-ID001",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
-            "condition": {
-                "items": ["T-Bar Handle"]
-            },
-            "excluded": 1
-    },
+	{
+			"name": "Falling Zombie",
+			"region": "Waterway Overpass",
+			"original_item": "",
+			"item_object": "Zombie_Waste02_FallBefor",
+			"parent_object": "17-315-0-2-ID001",
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+	},
     {
             "name": "Dark shirt Female Zombie",
             "region": "Upper Waterway",
@@ -682,7 +692,7 @@
             "parent_object": "17-429-0-1-ID006",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -693,7 +703,7 @@
             "parent_object": "17-429-0-0-ID004",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -704,7 +714,7 @@
             "parent_object": "17-429-0-1-ID002",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["T-Bar Handle"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -768,7 +778,7 @@
             "region": "Supplies Storage Room",
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
-            "parent_object": "17-327-0-0-ID008",
+            "parent_object": "17-327-0-2-ID008",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
     },
     {

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -150,7 +150,9 @@
         "region": "Press Room",
         "original_item": "Flamethrower Fuel",
         "condition": {
-            "items": ["Fuse - Main Hall", "Film - Hiding Place"]
+            "items": [
+			["Fuse - Main Hall", "Film - Hiding Place"], ["Spade Key", "Film - Hiding Place"]
+			]
         },    
         "item_object": "sm70_110",
         "parent_object": "ItemPos_TreasureA_Leon",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -2448,7 +2448,9 @@
         "name": "Final Hit on Super Tyrant",
         "region": "Path to Super Tyrant",
         "original_item": "Anti-tank Rocket",
-        "condition": {},    
+        "condition": {
+            "items": ["Joint Plug"]
+        },
         "item_object": "WP4600",
         "parent_object": "wp4600_rocketLauncher",
         "folder_path": "RopewayContents/World/Location_LaboratoryUndermost/Environments/st5_211_0/gimmick/CutScene",

--- a/residentevil2remake/data/leon/b/region_connections.json
+++ b/residentevil2remake/data/leon/b/region_connections.json
@@ -231,13 +231,13 @@
         "to": "Side Stairs"
     },
 	{ 
-        "from": "Main Hall",
-        "to": "Waiting Room",
+        "from": "Waiting Room",
+        "to": "Main Hall",
         "condition": {}
     },
     { 
-        "from": "Waiting Room",
-        "to": "East Hallway 2F",
+        "from": "East Hallway 2F",
+        "to": "Waiting Room",
         "condition": {
             "items": ["Spade Key"]
         }

--- a/residentevil2remake/docs/en_Resident Evil 2 Remake.md
+++ b/residentevil2remake/docs/en_Resident Evil 2 Remake.md
@@ -1,0 +1,45 @@
+# RE2R ARCHIPELAGO WORLD
+
+An Archipelago (AP) randomizer world for Resident Evil 2 Remake. Designed for use with the RE2R Archipelago client repository linked in the setup guide below.
+
+
+## HOW TO GET UP AND RUNNING
+
+Follow the visual setup guide here: [RE2R AP Setup Guide](https://fuzzygameson.github.io/RE2R_AP_SetupGuide/)
+
+
+## WHAT SCENARIOS DOES THIS SUPPORT?
+
+All 4 scenarios are supported: Leon and Claire, A/B or 1st/2nd scenarios.
+
+
+## WHAT DIFFICULTIES DOES THIS SUPPORT?
+
+All 3 difficulties are supported: Assisted, Standard, and Hardcore.
+
+
+## USUAL ASKS:
+
+## IS THIS OPEN WORLD?
+
+No. The story and access progression is very similar to the vanilla game, but item randomization does change how you route through the areas after they are unlocked.
+
+
+## WHY DO CLOCK TOWER / ROOF LADDER / MR. X NOT WORK WHILE I'M IN RPD 1?
+
+These are all activated by a trigger after leaving RPD 1 and fighting the G1 boss. They will not be active when you first arrive at RPD.
+
+
+## WANT TO CONTRIBUTE TO THIS APWORLD?
+
+Check out the Scenario Documentation for more information about how all the scenario locations and items are set up.
+
+Contributions are welcome. To submit contributions, make a PR from your fork of this repo and I'll review it for inclusion.
+
+
+## FEEDBACK OR QUESTIONS
+
+If you have feedback or questions about the rando, join the AP After Dark Discord and visit our game channel there. You can also submit issues on GitHub, but they will typically get a slower response than the Discord channel.
+
+
+

--- a/residentevil2remake/docs/setup_en.md
+++ b/residentevil2remake/docs/setup_en.md
@@ -1,0 +1,60 @@
+## Required Software
+
+* Resident Evil 2 Remake - Steam Non-RTX Beta Only
+* Praydog's REFramework - Frontend for our Client.
+* Resident Evil 2 Remake AP Client
+
+
+
+## Optional Visual Setup Guide
+
+[RE2R Visual Guide](https://fuzzygameson.github.io/RE2R_AP_SetupGuide/) - note that it only covers non-RTX
+
+Instructions
+
+1. Install [Praydog REFramework](https://github.com/praydog/REFramework/releases) - be sure to grab the non-rtx version of RE2R
+(You don't need to install the VR .dll files if you do not plan on using VR features)
+2. Install our [Non-RTX](https://github.com/FuzzyGamesOn/RE2R_AP_Client) client
+You should now be good to go. See below for more details on how to use the mod and connect to an Archipelago game.
+
+
+
+## Connecting to the Archipelago server
+
+To connect to the multiworld server, simply type in your connection info into the "Archipelago Client for REFramework" window that appears
+when you launch Resident Evil 2 Remake.
+
+
+
+## Console Commands
+
+You can use the same "Archipelago Client for REFramework" window to send commands.
+"!" commands such as "!hint" and "!release" will work from the client window, "/" commands will not and would need a separate text client.
+This may change in the future.
+
+
+
+## FAQ/Common Issues
+
+### I don't want to replay the beginning of Scenario A over and over!
+
+Do yourself a favor, and make a save at the Main Hall of the RPD when you first get there.
+
+**Be sure not to grab anything inside the RPD prior to making the save.**
+All items in it are part of the randomizer and grabbing any of them early prior to saving will delete them from any randomizers played afterwards.
+
+
+
+### The client windows aren't showing up when I start my game!
+
+Be sure to double check that you installed the proper clients for the version of the game you're running.
+Mismatching either Praydog's or ours to the installed version of your game will result in this behavior.
+
+
+
+### I died because I ran out of ammo, so I went back to an older save and now my items are missing, what can I do?
+
+The way the randomizer works, you should be starting back from whichever latest save you've made, autosaves count in this manner too.
+Starting from an older save will desync the items, but in the worst case if you do need to start from an older save or from the beginning you
+can push the "Receive Items Again" button within the "Archipelago Game Mod" window.
+


### PR DESCRIPTION
Plethora of enemy fixes across all scenarios;
-Fixes the broken G1 check for both Claire scenarios
-Fixes logic issues with enemies in the initial rooms of the RPD on both B scenarios so as to not have your main hall fuse or spade key sitting on an enemy check that is unreachable until later in the game, causing your world to be completely bricked without cheating the item in
-Some check names have been rewritten for parity - some enemies had a different check name between characters/scenarios despite being the same enemy previously
-Truly missable enemy checks have been excluded - this is largely focussed in the RPD with things like the first zombie that comes through the window in the west wing before entering the ops room that despawns once you return to marvin, or the helicopter crash zombies in the 2f east wing corridor that despawn once you go down the ladder from 3f to access the roof as examples. 

This isnt a complete exhaustive list by any means, but it has been tested a fair bit and tweaked to get to this point. 