### PR TITLE
Logic fixes in the Bottom Waterway - Supplies Storage Room area and JSON formatting fixes

### DIFF
--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -13,9 +13,9 @@
             "original_item": "",
             "item_object": "emZombie1FE2Window",
             "parent_object": "16-239-0-0-ID017",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
-			},
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "excluded": 1
+    },
     {
             "name": "Blonde Zombie",
             "region": "East Hallway 1F",
@@ -46,7 +46,7 @@
             "original_item": "",
             "item_object": "emZombie1FW2Window",
             "parent_object": "16-225-0-1-ID002",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
     },
     {
@@ -87,7 +87,7 @@
             "original_item": "",
             "item_object": "emZombie1FW1Window",
             "parent_object": "16-226-0-0-ID016",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
     },
     {
@@ -147,7 +147,7 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
 			"parent_object": "16-255-0-0-ID012",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
     },
     {
@@ -156,7 +156,7 @@
             "original_item": "",
             "item_object": "emZombie_2FECorrider",
             "parent_object": "16-255-0-0-ID216",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
     },
 	{
@@ -177,7 +177,7 @@
 			"original_item": "",
 			"item_object": "emZombie_1FEOffice2",
 			"parent_object": "16-230-0-0-ID203",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
 	},
 	{
@@ -186,7 +186,7 @@
 			"original_item": "",
 			"item_object": "emZombie_1FEOffice_Window",
 			"parent_object": "16-230-0-0-ID207",
-			"folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+			"folder_path": "RopewayManagers/TemporaryObjects/Enemy",
 			"excluded": 1
 	},
 	{
@@ -809,7 +809,10 @@
             "original_item": "",
             "item_object": "Zombie_Waste01_02",
             "parent_object": "17-327-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Queen Plug"]
+            }
     },
     {
             "name": "Fourth G-Adult before ladder",
@@ -817,7 +820,10 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/claire/a/enemies.json
+++ b/residentevil2remake/data/claire/a/enemies.json
@@ -811,7 +811,7 @@
             "parent_object": "17-327-0-0-ID007",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Queen Plug"]
+                "items": ["King Plug"]
             }
     },
     {

--- a/residentevil2remake/data/claire/a/locations.json
+++ b/residentevil2remake/data/claire/a/locations.json
@@ -1680,7 +1680,9 @@
         "name": "King Panel",
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
-        "condition": {},    
+        "condition": {
+            "items": ["Queen Plug"]
+        },
         "item_object": "KingB_sm42_208_PlugPlace01A_control",
         "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",

--- a/residentevil2remake/data/claire/a/region_connections.json
+++ b/residentevil2remake/data/claire/a/region_connections.json
@@ -446,9 +446,7 @@
     { 
         "from": "Bottom Waterway",
         "to": "Supplies Storage Room",
-        "condition": {
-            "items": ["Queen Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -847,7 +847,10 @@
             "original_item": "",
             "item_object": "Zombie_Waste01_02",
             "parent_object": "17-327-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Queen Plug"]
+            }
     },
     {
             "name": "Sleeping Overweight Zombie",
@@ -863,7 +866,10 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",

--- a/residentevil2remake/data/claire/b/enemies.json
+++ b/residentevil2remake/data/claire/b/enemies.json
@@ -849,7 +849,7 @@
             "parent_object": "17-327-0-0-ID007",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Queen Plug"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -858,7 +858,10 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
             "parent_object": "17-327-0-2-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "name": "Fourth G-Adult before ladder",
@@ -877,7 +880,10 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_man01",
             "parent_object": "17-325-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "name": "G-Adult upper waterway",

--- a/residentevil2remake/data/claire/b/locations.json
+++ b/residentevil2remake/data/claire/b/locations.json
@@ -1792,7 +1792,9 @@
         "name": "King Panel",
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
-        "condition": {},    
+        "condition": {
+            "items": ["Queen Plug"]
+        },
         "item_object": "KingB_sm42_208_PlugPlace01A_control",
         "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",

--- a/residentevil2remake/data/claire/b/region_connections.json
+++ b/residentevil2remake/data/claire/b/region_connections.json
@@ -474,9 +474,7 @@
     { 
         "from": "Bottom Waterway",
         "to": "Supplies Storage Room",
-        "condition": {
-            "items": ["Queen Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -810,7 +810,7 @@
             "parent_object": "17-327-0-0-ID007",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Queen Plug"]
+                "items": ["King Plug"]
             }
     },
     {

--- a/residentevil2remake/data/leon/a/enemies.json
+++ b/residentevil2remake/data/leon/a/enemies.json
@@ -808,7 +808,10 @@
             "original_item": "",
             "item_object": "Zombie_Waste01_02",
             "parent_object": "17-327-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Queen Plug"]
+            }
     },
     {
             "name": "Fourth G-Adult before ladder",
@@ -816,7 +819,10 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/leon/a/locations.json
+++ b/residentevil2remake/data/leon/a/locations.json
@@ -1724,7 +1724,9 @@
         "name": "King Panel",
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
-        "condition": {},    
+        "condition": {
+            "items": ["Queen Plug"]
+        },
         "item_object": "KingB_sm42_208_PlugPlace01A_control",
         "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",

--- a/residentevil2remake/data/leon/a/region_connections.json
+++ b/residentevil2remake/data/leon/a/region_connections.json
@@ -467,9 +467,7 @@
     { 
         "from": "Bottom Waterway",
         "to": "Supplies Storage Room",
-        "condition": {
-            "items": ["Queen Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -786,7 +786,10 @@
             "original_item": "",
             "item_object": "Zombie_Waste01_02",
             "parent_object": "17-327-0-0-ID007",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["Queen Plug"]
+            }
     },
     {
             "name": "Sleeping Overweight Zombie",
@@ -802,7 +805,10 @@
             "original_item": "",
             "item_object": "em6000_Swim",
             "parent_object": "17-325-0-8-nil",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "name": "Blue Jumpsuit Zombie on ledge near entrance ladder",

--- a/residentevil2remake/data/leon/b/enemies.json
+++ b/residentevil2remake/data/leon/b/enemies.json
@@ -788,7 +788,7 @@
             "parent_object": "17-327-0-0-ID007",
             "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
             "condition": {
-                "items": ["Queen Plug"]
+                "items": ["King Plug"]
             }
     },
     {
@@ -797,7 +797,10 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_fat01",
             "parent_object": "17-327-0-2-ID008",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "name": "Fourth G-Adult before ladder",
@@ -816,7 +819,10 @@
             "original_item": "",
             "item_object": "Zombie_WasteGAdultArea_man01",
             "parent_object": "17-325-0-0-ID024",
-            "folder_path": "RopewayManagers/TemporaryObjects/Enemy"
+            "folder_path": "RopewayManagers/TemporaryObjects/Enemy",
+            "condition": {
+                "items": ["King Plug"]
+            }
     },
     {
             "type": "Boss",

--- a/residentevil2remake/data/leon/b/locations.json
+++ b/residentevil2remake/data/leon/b/locations.json
@@ -1781,7 +1781,9 @@
         "name": "King Panel",
         "region": "Supplies Storage Room",
         "original_item": "King Plug",
-        "condition": {},    
+        "condition": {
+            "items": ["Queen Plug"]
+        },
         "item_object": "KingB_sm42_208_PlugPlace01A_control",
         "parent_object": "KingB_sm42_208_PlugPlace01A_control",
         "folder_path": "RopewayContents/World/Location_WasteWater/Environments/st3_625_0/gimmick",

--- a/residentevil2remake/data/leon/b/region_connections.json
+++ b/residentevil2remake/data/leon/b/region_connections.json
@@ -474,9 +474,7 @@
     { 
         "from": "Bottom Waterway",
         "to": "Supplies Storage Room",
-        "condition": {
-            "items": ["Queen Plug"]
-        }
+        "condition": {}
     },
     { 
         "from": "Upper Waterway",


### PR DESCRIPTION
# What does this PR do?

## JSON formatting fixes
Claire A enemies.json had some invalid JSON entries when the exclusions were made. These should be fixed.

## Logic fixes in the Bottom Waterway - Supplies Storage Room area
- As discussed in the RE2 channel, the Supplies Storage Room region doesn't need the Queen plug as an entrance condition, select few items can be aquired just by going into the room. That region connection entry has been changed, suffitient logic was added
- Changed logic entries for enemies that need the King plug to spawn, and changed enemies to only be in logic when they're in their "active state". If zombies only being in logic when they're in their active state should be the standard for the future then it'll require a revision of some other zombie kill locations as well. (An example would be the firing range zombies, this PR only covers the regions described above)