### PR TITLE
Enemy Kills options become Killsanity, final Tyrant teleport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/*
 **/*.pyc
 **/*.txt
 **/*.apworld
+**/archipelago.json

--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -141,7 +141,7 @@ class AllowProgressionInLabs(Choice):
     option_true = 1
     default = 0
 
-class AddEnemyKillsAsLocations(Choice):
+class Killsanity(Choice):
     """When enabled, multiworld items are also placed on the enemies in your world. Killing those enemies gives the item.
 
     Currently only supports Leon's A (1st) scenario on Assisted / Standard difficulty.
@@ -153,15 +153,18 @@ class AddEnemyKillsAsLocations(Choice):
     None: You decided not to add hundreds of enemy locations to your world. Probably a good idea tbh.
     All: Every reachable enemy from the beginning of RPD to the end of the game now gives an item when killed.
     """
-    display_name = "Add Enemy Kills as Locations"
+    display_name = "Killsanity"
     option_none = 0
     option_all = 1
     default = 0
 
-class EnemyKillItems(Choice):
-    """While the Add Enemy Kills as Locations option is enabled, this option specifies the items that each kill adds to the item pool.
+class KillsanityItemPoolAdditions(Choice):
+    """While the Killsanity option is enabled, this option specifies the items that each kill adds to the item pool.
 
-    (The items you choose here are STILL randomized. It's just that enemies don't drop items at all in RE2R, so we have to ask what they should have *vanilla*.)
+    *****This DOES NOT mean that the enemies will drop whatever item you set here.*****
+
+    The items you choose here are **STILL randomized**.
+    It's just that enemies don't drop items at all in RE2R, so we have to ask what "vanilla" item you want them to have... which then gets randomized.
 
     The available options are:
 
@@ -173,7 +176,7 @@ class EnemyKillItems(Choice):
     Healing: Only healing items are added.
     Trash: Only filler items are added.
     """
-    display_name = "Enemy Item Kills"
+    display_name = "Killsanity - Item Pool Additions"
     option_mixed = 0
     option_all_weapon_related = 1
     option_ammo_related = 2
@@ -401,8 +404,8 @@ class RE2ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     extra_medallions: ExtraMedallions
     early_medallions: EarlyMedallions
     allow_progression_in_labs: AllowProgressionInLabs
-    add_enemy_kills_as_locations: AddEnemyKillsAsLocations
-    enemy_kill_items: EnemyKillItems
+    killsanity: Killsanity
+    killsanity_item_pool_additions: KillsanityItemPoolAdditions
     cross_scenario_weapons: CrossScenarioWeapons
     ammo_pack_modifier: AmmoPackModifier
     local_weapons: LocalWeapons

--- a/residentevil2remake/Options.py
+++ b/residentevil2remake/Options.py
@@ -424,7 +424,7 @@ class RE2ROptions(StartInventoryFromPoolMixin, DeathLinkMixin, PerGameCommonOpti
     add_poison_traps: AddPoisonTraps
     poison_trap_count: PoisonTrapCount
 
-residentevil2remake_option_groups = [
+RE2ROptionGroups = [
     OptionGroup("Helper Options", [
         BonusStart,
         StartingHipPouches,
@@ -441,8 +441,8 @@ residentevil2remake_option_groups = [
         AmmoPackModifier,
     ]),
     OptionGroup("Enemy Kill Options", [
-        AddEnemyKillsAsLocations,
-        EnemyKillItems,
+        Killsanity,
+        KillsanityItemPoolAdditions,
     ]),
     OptionGroup("Challenge Options", [
         OopsAllRockets,

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -69,11 +69,6 @@ class ResidentEvil2Remake(World):
             # gets the int val from the string option value name, then sets
             getattr(self.options, key).value = getattr(self.options, key).options[val]
 
-        # if the enemy kills as locations option is enabled for a scenario that doesn't support it yet, throw an error
-        if self._enemy_kill_rando() and not self._can_enemy_kill_rando():
-            raise RE2ROptionError("The Enemy Kills as Locations option is only currently supported for Leon's A (1st) scenario on Assisted / Standard difficulty.")
-            return
-
         # start with the normal locations per player for pool, then overwrite with weapon rando if needed
         self.source_locations[self.player] = self._get_locations_for_scenario(self._get_character(), self._get_scenario()) # id:loc combo
         self.source_locations[self.player] = { 
@@ -81,54 +76,54 @@ class ResidentEvil2Remake(World):
                 for i, l in self.source_locations[self.player].items() 
         } # turn it into name:loc instead
 
-        if self._enemy_kill_rando():
+        if self._killsanity():
             # since enemy kills don't give items themselves, create a drop table of 
             # combat-related items to add to the pool for these locations
-            enemy_kill_items = self._format_option_text(self.options.enemy_kill_items).lower()
+            killsanity_items = self._format_option_text(self.options.killsanity_item_pool_additions).lower()
 
-            if enemy_kill_items == "Trash":
-                enemy_kill_valid_drops = [
+            if killsanity_items == "Trash":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Lore'] or 'Trophy' in i['name'] 
                 ]   
-            elif enemy_kill_items == "Healing":
-                enemy_kill_valid_drops = [
+            elif killsanity_items == "Healing":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Recovery'] 
                 ]
-            elif enemy_kill_items == "Gunpowder":
-                enemy_kill_valid_drops = [
+            elif killsanity_items == "Gunpowder":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if 'Gunpowder' in i['name'] 
                 ]
-            elif enemy_kill_items == "Ammo":
-                enemy_kill_valid_drops = [
+            elif killsanity_items == "Ammo":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Ammo'] 
                 ]
-            elif enemy_kill_items == "Ammo Related":
-                enemy_kill_valid_drops = [
+            elif killsanity_items == "Ammo Related":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Ammo'] or 'Gunpowder' in i['name'] 
                 ]
-            elif enemy_kill_items == "All Weapon Related":
-                enemy_kill_valid_drops = [
+            elif killsanity_items == "All Weapon Related":
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Ammo', 'Subweapon'] or 'Gunpowder' in i['name'] 
                 ]
             else: # == "Mixed"
-                enemy_kill_valid_drops = [
+                killsanity_valid_drops = [
                     i['name'] for i in Data.item_table if i.get('type', 'None') in ['Recovery', 'Ammo', 'Subweapon'] or 'Gunpowder' in i['name'] 
                 ]   
 
             # get the list of viable items from the list of items currently on the scenario's locations
-            enemy_kill_drop_names = list(set([
-                l['original_item'] for l in self.source_locations[self.player].values() if l.get('original_item', 'None') in enemy_kill_valid_drops
+            killsanity_drop_names = list(set([
+                l['original_item'] for l in self.source_locations[self.player].values() if l.get('original_item', 'None') in killsanity_valid_drops
             ]))
-            enemy_kill_drops = []
+            killsanity_drops = []
 
             for x in range(len(Data.enemy_table)):
-                drop_name = enemy_kill_drop_names[x % len(enemy_kill_drop_names)]
-                enemy_kill_drops.append(drop_name)
+                drop_name = killsanity_drop_names[x % len(killsanity_drop_names)]
+                killsanity_drops.append(drop_name)
 
             # replace placeholders for enemy kills with the chosen distribution of items
             for name, loc in self.source_locations[self.player].items():
                 if loc.get('original_item') == "__Enemy Kill Drop Placeholder__":
-                    loc['original_item'] = enemy_kill_drops.pop(0)
+                    loc['original_item'] = killsanity_drops.pop(0)
 
         weapon_rando = self._format_option_text(self.options.cross_scenario_weapons).lower()
 
@@ -237,7 +232,7 @@ class ResidentEvil2Remake(World):
                 # END if
 
                 # if the player doesn't have a fire weapon or rocket launchers in their item pool, make all Ivy enemy drops give filler / be useless
-                if self._enemy_kill_rando() and "Ivy" in location.name and not has_fire_weapon:
+                if self._killsanity() and "Ivy" in location.name and not has_fire_weapon:
                     location.progress_type = LocationProgressType.EXCLUDED
                     location.place_locked_item(self.create_item("Pink Scissors"))
 
@@ -482,7 +477,7 @@ class ResidentEvil2Remake(World):
 
             replacement_types = ['Weapon', 'Subweapon', 'Ammo']
 
-            if self._enemy_kill_rando(): # if enemy kill rando, just replace gunpowder with the Oops weapon; players will need more firepower
+            if self._killsanity(): # if enemy kill rando, just replace gunpowder with the Oops weapon; players will need more firepower
                 replacement_types.append('Gunpowder')
             else: # otherwise, we don't want the player to have gunpowder for bullets to make Oops options more thematic, so we swap them to random filler
                 replacements = [
@@ -592,7 +587,7 @@ class ResidentEvil2Remake(World):
             pool.remove(eligible_items[0])
 
         # if enemy kills are added to the locations, remove all Wooden Boards so that players don't prevent themselves from killing window vaulting enemies
-        if self._enemy_kill_rando():
+        if self._killsanity():
             if self._get_oops_all_options_flag():
                 pool = self._replace_pool_item_with(pool, "Wooden Boards", "Blue Herb") # enemy kill rando removes all gunpowder with Oops, so use a different replacement
             else:
@@ -627,6 +622,7 @@ class ResidentEvil2Remake(World):
             "scenario": self._get_scenario(),
             "difficulty": self._get_difficulty(),
             "unlocked_typewriters": self._format_option_text(self.options.unlocked_typewriters).split(", "),
+            "killsanity": self._format_option_text(self.options.killsanity),
             "weapon_rando": self._format_option_text(self.options.cross_scenario_weapons),
             "starting_weapon": self._get_starting_weapon(),
             "all_weapons": self._get_all_weapons(),
@@ -742,7 +738,7 @@ class ResidentEvil2Remake(World):
                 if loc['character'] == character and loc['scenario'] == scenario
         }
 
-        if self._enemy_kill_rando():
+        if self._killsanity():
             locations_pool.update({
                 enemy['id']: enemy for enemy in Data.enemy_table
                     if enemy['character'] == character and enemy['scenario'] == scenario
@@ -848,39 +844,6 @@ class ResidentEvil2Remake(World):
             flag |= 0x08
         return flag
        
-    def _enemy_kill_rando(self) -> bool:
-        return self._format_option_text(self.options.add_enemy_kills_as_locations) != "None"
+    def _killsanity(self) -> bool:
+        return self._format_option_text(self.options.killsanity) != "None"
 
-    def _can_enemy_kill_rando(self) -> bool:
-        return True # should be supported for all scenarios now thanks to contributions
-
-    # def _output_items_and_locations_as_text(self):
-    #     my_locations = [
-    #         {
-    #             'id': loc.address,
-    #             'name': loc.name,
-    #             'original_item': self.location_name_to_location[loc.name]['original_item'] if loc.name != "Victory" else "(Game Complete)"
-    #         } for loc in self.multiworld.get_locations() if loc.player == self.player
-    #     ]
-
-    #     my_locations = set([
-    #         "{} | {} | {}".format(loc['id'], loc['name'], loc['original_item'])
-    #         for loc in my_locations
-    #     ])
-        
-    #     my_items = [
-    #         {
-    #             'id': item.code,
-    #             'name': item.name
-    #         } for item in self.multiworld.get_items() if item.player == self.player
-    #     ]
-
-    #     my_items = set([
-    #         "{} | {}".format(item['id'], item['name'])
-    #         for item in my_items
-    #     ])
-
-    #     print("\n".join(sorted(my_locations)))
-    #     print("\n".join(sorted(my_items)))
-
-    #     raise BaseException("Done with debug output.")

--- a/residentevil2remake/__init__.py
+++ b/residentevil2remake/__init__.py
@@ -11,7 +11,7 @@ from Fill import fill_restrictive
 
 from .Data import Data
 from .Exceptions import RE2ROptionError
-from .Options import RE2ROptions, residentevil2remake_option_groups
+from .Options import RE2ROptions, RE2ROptionGroups
 from .WeaponRandomizer import WeaponRandomizer
 
 
@@ -30,7 +30,7 @@ class RPDNet(WebWorld):
         "setup/en",
         ["FuzzyGamesOn"]
     )]
-    option_groups = residentevil2remake_option_groups
+    option_groups = RE2ROptionGroups
 
 
 class RE2RLocation(Location):

--- a/residentevil2remake/data/leon/a/typewriters.json
+++ b/residentevil2remake/data/leon/a/typewriters.json
@@ -109,5 +109,12 @@
         "map_id": 373, 
         "player_position": [-0.9, -78.51, 17.5], 
         "item_object": "sm41_000_Typewriter01A_Lift_control" 
+    },
+    {
+        "name": "Tyrant - Final Battle",
+        "location_id": 21,
+        "map_id": 373,
+        "player_position": [48.38, -101.62, 16.48],
+        "item_object": "CheckPoint_NTyrant"
     }
 ]

--- a/residentevil2remake/data/leon/b/typewriters.json
+++ b/residentevil2remake/data/leon/b/typewriters.json
@@ -102,5 +102,12 @@
         "map_id": 373, 
         "player_position": [-0.9, -78.51, 17.5], 
         "item_object": "sm41_000_Typewriter01A_Lift_control" 
+    },
+    {
+        "name": "Tyrant - Final Battle",
+        "location_id": 21,
+        "map_id": 373,
+        "player_position": [48.38, -101.62, 16.48],
+        "item_object": "CheckPoint_NTyrant"
     }
 ]


### PR DESCRIPTION
This one's a bit more on-topic than the other, keeping it simple.

List of features included:
- Ignore the archipelago.json so it doesn't get committed (it gets generated on release)
- Rename Enemy Kills to Killsanity; it's what everyone calls it anyways
- Add a disclaimer to Enemy Kill Items option for people who don't read good
- Added final Tyrant fight as a teleport for Leon scenarios